### PR TITLE
fix 'used before set' warning.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -229,9 +229,11 @@ install-doc: doc
 	@$(INSTALL_DATA_DIR) $(DESTDIR)$(mandir)/mann
 	@echo "Installing documentation in $(DESTDIR)$(mandir)"
 	@list='$(srcdir)/doc/man/*.n'; for i in $$list; do \
-	    echo "Installing $$i"; \
-	    rm -f $(DESTDIR)$(mandir)/mann/`basename $$i`; \
-	    $(INSTALL_DATA) $$i $(DESTDIR)$(mandir)/mann ; \
+	    if [ -f $$i ]; then \
+	        echo "Installing $$i"; \
+	        rm -f $(DESTDIR)$(mandir)/mann/`basename $$i`; \
+	        $(INSTALL_DATA) $$i $(DESTDIR)$(mandir)/mann ; \
+	    fi; \
 	done
 
 test: binaries libraries

--- a/generic/tclStrIdxTree.c
+++ b/generic/tclStrIdxTree.c
@@ -86,7 +86,7 @@ TclStrIdxTreeSearch(
 {
     TclStrIdxTree *parent = tree, *prevParent = tree;
     TclStrIdx  *item = tree->firstPtr, *prevItem = NULL;
-    const char *s = start, *f, *cin, *cinf, *prevf;
+    const char *s = start, *f, *cin, *cinf, *prevf = NULL;
     int offs = 0;
 
     if (item == NULL) {


### PR DESCRIPTION
Initialize prevf to fix (used before set) warning.

* Prevf doesn't get used at line 145 unless `prevItem != NULL` and prevf also gets set in the same block, so this is safe.


