### PR TITLE
Fixes TZ env anchor

### DIFF
--- a/generic/tclClock.c
+++ b/generic/tclClock.c
@@ -4234,11 +4234,8 @@ TzsetIfNecessary(void)
 					  * clockMutex. */
     static long	 tzLastRefresh = 0;	 /* Used for latency before next refresh */
     static size_t tzWasEpoch = 0;        /* Epoch, signals that TZ changed */
-#if TCL_AVAIL_SBMOD
     static size_t tzEnvEpoch = 0;        /* Last env epoch, for faster signaling,
 					    that TZ changed via TCL */
-#endif /* TCL_AVAIL_SBMOD */
-
     const char *tzIsNow;		 /* Current value of TZ */
 
     /*
@@ -4248,17 +4245,11 @@ TzsetIfNecessary(void)
      */
     Tcl_Time now;
     Tcl_GetTime(&now);
-    if (now.sec == tzLastRefresh
-#if TCL_AVAIL_SBMOD
-     && tzEnvEpoch == TclEnvEpoch
-#endif /* TCL_AVAIL_SBMOD */
-    ) {
+    if (now.sec == tzLastRefresh && tzEnvEpoch == TclEnvEpoch) {
 	return tzWasEpoch;
     }
 
-#if TCL_AVAIL_SBMOD
     tzEnvEpoch = TclEnvEpoch;
-#endif /* TCL_AVAIL_SBMOD */
     tzLastRefresh = now.sec;
 
     /* check in lock */

--- a/generic/tclDate.h
+++ b/generic/tclDate.h
@@ -376,6 +376,10 @@ typedef struct ClockClientData {
 	/* values */
 	int	    tzOffset;
     } local2utc;
+
+    size_t tzEnvEpoch;		    /* Last env epoch, for faster signaling,
+				       that TZ changed via TCL */
+
 } ClockClientData;
 
 #define ClockDefaultYearCentury 2000

--- a/generic/tclDate.h
+++ b/generic/tclDate.h
@@ -40,6 +40,9 @@ MODULE_SCOPE int TclCompileClockClicksCmd(Tcl_Interp *interp, Tcl_Parse *parsePt
 MODULE_SCOPE int TclCompileClockReadingCmd(Tcl_Interp *interp, Tcl_Parse *parsePtr, 
     struct Command *cmdPtr, struct CompileEnv *compEnvPtr);
 
+MODULE_SCOPE size_t TclEnvEpoch;        /* Epoch of the tcl environment
+                                         * (if changed with tcl-env). */
+
 #else
 
 #define tclIntTypePtr     (&tclIntType)


### PR DESCRIPTION
- added trace hook for env-epoch (ported from core `generic/tclEnv.c`, branch `sebres-8-6-clock-speedup-cr1`);
- restored cache anchor to TclEnvEpoch by caching of current timezone (fixed test `clock-38.2`).
- better anchoring to the epoch of tcl-env: may be different between interpreters, thus moved to clock client data