### PR TITLE
Freescan tz fix

### DIFF
--- a/generic/tclDate.c
+++ b/generic/tclDate.c
@@ -1,20 +1,20 @@
 /* A Bison parser, made by GNU Bison 2.4.2.  */
 
 /* Skeleton implementation for Bison's Yacc-like parsers in C
-
+   
       Copyright (C) 1984, 1989-1990, 2000-2006, 2009-2010 Free Software
    Foundation, Inc.
-
+   
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -27,7 +27,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-
+   
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -455,16 +455,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   75
+#define YYLAST   80
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  26
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  16
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  55
+#define YYNRULES  56
 /* YYNRULES -- Number of states.  */
-#define YYNSTATES  79
+#define YYNSTATES  81
 
 /* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
 #define YYUNDEFTOK  2
@@ -513,10 +513,10 @@ static const yytype_uint8 yyprhs[] =
 {
        0,     0,     3,     4,     7,     9,    11,    13,    15,    17,
       19,    21,    23,    25,    28,    33,    40,    43,    45,    47,
-      50,    52,    55,    58,    62,    65,    69,    75,    77,    83,
-      89,    92,    97,   100,   102,   106,   109,   113,   117,   125,
-     128,   133,   136,   138,   142,   145,   148,   152,   154,   156,
-     158,   160,   162,   164,   166,   167
+      50,    54,    56,    59,    62,    66,    69,    73,    79,    81,
+      87,    93,    96,   101,   104,   106,   110,   113,   117,   121,
+     129,   132,   137,   140,   142,   146,   149,   152,   156,   158,
+     160,   162,   164,   166,   168,   170,   171
 };
 
 /* YYRHS -- A `-1'-separated list of the rules' RHS.  */
@@ -527,18 +527,19 @@ static const yytype_int8 yyrhs[] =
       -1,    35,    -1,    40,    -1,    13,     7,    -1,    13,    20,
       13,    41,    -1,    13,    20,    13,    20,    13,    41,    -1,
       14,    16,    -1,    14,    -1,     5,    -1,    38,    13,    -1,
-       4,    -1,     4,    21,    -1,    13,     4,    -1,    38,    13,
-       4,    -1,    19,     4,    -1,    13,    22,    13,    -1,    13,
-      22,    13,    22,    13,    -1,    17,    -1,    13,    23,     8,
-      23,    13,    -1,    13,    23,    13,    23,    13,    -1,     8,
-      13,    -1,     8,    13,    21,    13,    -1,    13,     8,    -1,
-      15,    -1,    13,     8,    13,    -1,    19,     8,    -1,    19,
-      13,     8,    -1,    17,    14,    17,    -1,    17,    14,    13,
-      20,    13,    20,    13,    -1,    17,    17,    -1,    10,    13,
-      24,    13,    -1,    37,     3,    -1,    37,    -1,    38,    13,
-      39,    -1,    13,    39,    -1,    19,    39,    -1,    19,    13,
-      39,    -1,    39,    -1,    23,    -1,    25,    -1,    11,    -1,
-      18,    -1,     9,    -1,    13,    -1,    -1,     7,    -1
+      14,    38,    13,    -1,     4,    -1,     4,    21,    -1,    13,
+       4,    -1,    38,    13,     4,    -1,    19,     4,    -1,    13,
+      22,    13,    -1,    13,    22,    13,    22,    13,    -1,    17,
+      -1,    13,    23,     8,    23,    13,    -1,    13,    23,    13,
+      23,    13,    -1,     8,    13,    -1,     8,    13,    21,    13,
+      -1,    13,     8,    -1,    15,    -1,    13,     8,    13,    -1,
+      19,     8,    -1,    19,    13,     8,    -1,    17,    14,    17,
+      -1,    17,    14,    13,    20,    13,    20,    13,    -1,    17,
+      17,    -1,    10,    13,    24,    13,    -1,    37,     3,    -1,
+      37,    -1,    38,    13,    39,    -1,    13,    39,    -1,    19,
+      39,    -1,    19,    13,    39,    -1,    39,    -1,    23,    -1,
+      25,    -1,    11,    -1,    18,    -1,     9,    -1,    13,    -1,
+      -1,     7,    -1
 };
 
 /* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
@@ -546,10 +547,10 @@ static const yytype_uint16 yyrline[] =
 {
        0,   152,   152,   153,   156,   159,   162,   165,   168,   171,
      174,   178,   183,   186,   192,   198,   206,   210,   214,   218,
-     224,   228,   232,   236,   240,   246,   250,   255,   260,   265,
-     270,   274,   279,   283,   288,   295,   299,   305,   314,   323,
-     333,   347,   352,   355,   358,   361,   364,   367,   372,   375,
-     380,   384,   388,   394,   412,   415
+     222,   228,   232,   236,   240,   244,   250,   254,   259,   264,
+     269,   274,   278,   283,   287,   292,   299,   303,   309,   318,
+     327,   337,   351,   356,   359,   362,   365,   368,   371,   376,
+     379,   384,   388,   392,   398,   416,   419
 };
 #endif
 
@@ -584,10 +585,10 @@ static const yytype_uint8 yyr1[] =
 {
        0,    26,    27,    27,    28,    28,    28,    28,    28,    28,
       28,    28,    28,    29,    29,    29,    30,    30,    30,    30,
-      31,    31,    31,    31,    31,    32,    32,    32,    32,    32,
-      32,    32,    32,    32,    32,    33,    33,    34,    34,    34,
-      35,    36,    36,    37,    37,    37,    37,    37,    38,    38,
-      39,    39,    39,    40,    41,    41
+      30,    31,    31,    31,    31,    31,    32,    32,    32,    32,
+      32,    32,    32,    32,    32,    32,    33,    33,    34,    34,
+      34,    35,    36,    36,    37,    37,    37,    37,    37,    38,
+      38,    39,    39,    39,    40,    41,    41
 };
 
 /* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
@@ -595,10 +596,10 @@ static const yytype_uint8 yyr2[] =
 {
        0,     2,     0,     2,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     2,     4,     6,     2,     1,     1,     2,
-       1,     2,     2,     3,     2,     3,     5,     1,     5,     5,
-       2,     4,     2,     1,     3,     2,     3,     3,     7,     2,
-       4,     2,     1,     3,     2,     2,     3,     1,     1,     1,
-       1,     1,     1,     1,     0,     1
+       3,     1,     2,     2,     3,     2,     3,     5,     1,     5,
+       5,     2,     4,     2,     1,     3,     2,     3,     3,     7,
+       2,     4,     2,     1,     3,     2,     2,     3,     1,     1,
+       1,     1,     1,     1,     1,     0,     1
 };
 
 /* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
@@ -606,21 +607,22 @@ static const yytype_uint8 yyr2[] =
    means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       2,     0,     1,    20,    18,     0,    52,     0,    50,    53,
-      17,    33,    27,    51,     0,    48,    49,     3,     4,     5,
-       8,     6,     7,    10,    11,     9,    42,     0,    47,    12,
-      21,    30,     0,    22,    13,    32,     0,     0,     0,    44,
-      16,     0,    39,    24,    35,     0,    45,    41,    19,     0,
-       0,    34,    54,    25,     0,     0,     0,    37,    36,    46,
-      23,    43,    31,    40,    55,     0,    14,     0,     0,     0,
-       0,    54,    26,    28,    29,     0,    15,     0,    38
+       2,     0,     1,    21,    18,     0,    53,     0,    51,    54,
+      17,    34,    28,    52,     0,    49,    50,     3,     4,     5,
+       8,     6,     7,    10,    11,     9,    43,     0,    48,    12,
+      22,    31,     0,    23,    13,    33,     0,     0,     0,    45,
+      16,     0,     0,    40,    25,    36,     0,    46,    42,    19,
+       0,     0,    35,    55,    26,     0,     0,    20,     0,    38,
+      37,    47,    24,    44,    32,    41,    56,     0,    14,     0,
+       0,     0,     0,    55,    27,    29,    30,     0,    15,     0,
+      39
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
       -1,     1,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    66
+      25,    26,    27,    28,    29,    68
 };
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
@@ -628,21 +630,22 @@ static const yytype_int8 yydefgoto[] =
 #define YYPACT_NINF -18
 static const yytype_int8 yypact[] =
 {
-     -18,     2,   -18,   -17,   -18,    -4,   -18,    10,   -18,    22,
-       8,   -18,    18,   -18,    39,   -18,   -18,   -18,   -18,   -18,
-     -18,   -18,   -18,   -18,   -18,   -18,    25,    21,   -18,   -18,
-     -18,    16,    14,   -18,   -18,    28,    36,    41,    -5,   -18,
-     -18,     5,   -18,   -18,   -18,    47,   -18,   -18,    42,    46,
-      48,   -18,    -6,    40,    43,    44,    49,   -18,   -18,   -18,
-     -18,   -18,   -18,   -18,   -18,    50,   -18,    51,    55,    57,
-      58,    65,   -18,   -18,   -18,    53,   -18,    61,   -18
+     -18,     2,   -18,   -17,   -18,    -4,   -18,    11,   -18,    24,
+      35,   -18,     9,   -18,    30,   -18,   -18,   -18,   -18,   -18,
+     -18,   -18,   -18,   -18,   -18,   -18,    26,    17,   -18,   -18,
+     -18,    15,    25,   -18,   -18,    42,    44,    48,    -5,   -18,
+     -18,    49,     5,   -18,   -18,   -18,    45,   -18,   -18,    41,
+      51,    52,   -18,    -6,    46,    43,    47,   -18,    53,   -18,
+     -18,   -18,   -18,   -18,   -18,   -18,   -18,    54,   -18,    56,
+      58,    59,    61,    68,   -18,   -18,   -18,    57,   -18,    63,
+     -18
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
      -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,
-     -18,   -18,   -18,    -9,   -18,     4
+     -18,   -18,    69,    -9,   -18,     7
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
@@ -652,26 +655,28 @@ static const yytype_int8 yypgoto[] =
 #define YYTABLE_NINF -1
 static const yytype_uint8 yytable[] =
 {
-      39,    64,     2,    54,    30,    46,     3,     4,    55,    31,
-       5,     6,     7,     8,    65,     9,    10,    11,    56,    12,
-      13,    14,    57,    32,    40,    15,    33,    16,    47,    34,
-      35,     6,    41,     8,    48,    42,    59,    49,    50,    61,
-      13,    51,    36,    43,    37,    38,    60,    44,     6,    52,
-       8,     6,    45,     8,    53,    58,     6,    13,     8,    62,
-      13,    63,    67,    71,    72,    13,    68,    69,    73,    70,
-      74,    75,    64,    77,    78,    76
+      39,    66,     2,    55,    30,    47,     3,     4,    56,    31,
+       5,     6,     7,     8,    67,     9,    10,    11,    58,    12,
+      13,    14,    59,    42,    32,    15,    43,    16,    33,    48,
+      49,    34,    35,     6,    44,     8,    50,    61,    45,     6,
+      63,     8,    13,    46,    36,    62,    37,    38,    13,    51,
+       6,    40,     8,    60,     6,    52,     8,    53,    15,    13,
+      16,    54,    57,    13,    64,    65,    70,    73,    69,    74,
+      71,    75,    76,    72,    77,    66,    80,    79,     0,    41,
+      78
 };
 
-static const yytype_uint8 yycheck[] =
+static const yytype_int8 yycheck[] =
 {
        9,     7,     0,     8,    21,    14,     4,     5,    13,    13,
        8,     9,    10,    11,    20,    13,    14,    15,    13,    17,
-      18,    19,    17,    13,    16,    23,     4,    25,     3,     7,
-       8,     9,    14,    11,    13,    17,    45,    21,    24,    48,
-      18,    13,    20,     4,    22,    23,     4,     8,     9,    13,
-      11,     9,    13,    11,    13,     8,     9,    18,    11,    13,
-      18,    13,    22,    13,    13,    18,    23,    23,    13,    20,
-      13,    13,     7,    20,    13,    71
+      18,    19,    17,    14,    13,    23,    17,    25,     4,     3,
+      13,     7,     8,     9,     4,    11,    21,    46,     8,     9,
+      49,    11,    18,    13,    20,     4,    22,    23,    18,    24,
+       9,    16,    11,     8,     9,    13,    11,    13,    23,    18,
+      25,    13,    13,    18,    13,    13,    23,    13,    22,    13,
+      23,    13,    13,    20,    13,     7,    13,    20,    -1,    10,
+      73
 };
 
 /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
@@ -682,10 +687,11 @@ static const yytype_uint8 yystos[] =
       14,    15,    17,    18,    19,    23,    25,    28,    29,    30,
       31,    32,    33,    34,    35,    36,    37,    38,    39,    40,
       21,    13,    13,     4,     7,     8,    20,    22,    23,    39,
-      16,    14,    17,     4,     8,    13,    39,     3,    13,    21,
-      24,    13,    13,    13,     8,    13,    13,    17,     8,    39,
-       4,    39,    13,    13,     7,    20,    41,    22,    23,    23,
-      20,    13,    13,    13,    13,    13,    41,    20,    13
+      16,    38,    14,    17,     4,     8,    13,    39,     3,    13,
+      21,    24,    13,    13,    13,     8,    13,    13,    13,    17,
+       8,    39,     4,    39,    13,    13,     7,    20,    41,    22,
+      23,    23,    20,    13,    13,    13,    13,    13,    41,    20,
+      13
 };
 
 #define yyerrok		(yyerrstatus = 0)
@@ -1669,8 +1675,8 @@ yyreduce:
   case 20:
 
     {
-	    yyDayOrdinal = 1;
-	    yyDayNumber = (yyvsp[(1) - (1)].Number);
+	    yyTimezone = (yyvsp[(1) - (3)].Number) - (yyvsp[(2) - (3)].Number)*((yyvsp[(3) - (3)].Number) % 100 + ((yyvsp[(3) - (3)].Number) / 100) * 60);
+	    yyDSTmode = DSToff;
 	;}
     break;
 
@@ -1678,11 +1684,19 @@ yyreduce:
 
     {
 	    yyDayOrdinal = 1;
-	    yyDayNumber = (yyvsp[(1) - (2)].Number);
+	    yyDayNumber = (yyvsp[(1) - (1)].Number);
 	;}
     break;
 
   case 22:
+
+    {
+	    yyDayOrdinal = 1;
+	    yyDayNumber = (yyvsp[(1) - (2)].Number);
+	;}
+    break;
+
+  case 23:
 
     {
 	    yyDayOrdinal = (yyvsp[(1) - (2)].Number);
@@ -1690,7 +1704,7 @@ yyreduce:
 	;}
     break;
 
-  case 23:
+  case 24:
 
     {
 	    yyDayOrdinal = (yyvsp[(1) - (3)].Number) * (yyvsp[(2) - (3)].Number);
@@ -1698,7 +1712,7 @@ yyreduce:
 	;}
     break;
 
-  case 24:
+  case 25:
 
     {
 	    yyDayOrdinal = 2;
@@ -1706,7 +1720,7 @@ yyreduce:
 	;}
     break;
 
-  case 25:
+  case 26:
 
     {
 	    yyMonth = (yyvsp[(1) - (3)].Number);
@@ -1714,7 +1728,7 @@ yyreduce:
 	;}
     break;
 
-  case 26:
+  case 27:
 
     {
 	    yyMonth = (yyvsp[(1) - (5)].Number);
@@ -1723,7 +1737,7 @@ yyreduce:
 	;}
     break;
 
-  case 27:
+  case 28:
 
     {
 	    yyYear = (yyvsp[(1) - (1)].Number) / 10000;
@@ -1732,7 +1746,7 @@ yyreduce:
 	;}
     break;
 
-  case 28:
+  case 29:
 
     {
 	    yyDay = (yyvsp[(1) - (5)].Number);
@@ -1741,7 +1755,7 @@ yyreduce:
 	;}
     break;
 
-  case 29:
+  case 30:
 
     {
 	    yyMonth = (yyvsp[(3) - (5)].Number);
@@ -1750,7 +1764,7 @@ yyreduce:
 	;}
     break;
 
-  case 30:
+  case 31:
 
     {
 	    yyMonth = (yyvsp[(1) - (2)].Number);
@@ -1758,7 +1772,7 @@ yyreduce:
 	;}
     break;
 
-  case 31:
+  case 32:
 
     {
 	    yyMonth = (yyvsp[(1) - (4)].Number);
@@ -1767,7 +1781,7 @@ yyreduce:
 	;}
     break;
 
-  case 32:
+  case 33:
 
     {
 	    yyMonth = (yyvsp[(2) - (2)].Number);
@@ -1775,7 +1789,7 @@ yyreduce:
 	;}
     break;
 
-  case 33:
+  case 34:
 
     {
 	    yyMonth = 1;
@@ -1784,7 +1798,7 @@ yyreduce:
 	;}
     break;
 
-  case 34:
+  case 35:
 
     {
 	    yyMonth = (yyvsp[(2) - (3)].Number);
@@ -1793,7 +1807,7 @@ yyreduce:
 	;}
     break;
 
-  case 35:
+  case 36:
 
     {
 	    yyMonthOrdinalIncr = 1;
@@ -1801,7 +1815,7 @@ yyreduce:
 	;}
     break;
 
-  case 36:
+  case 37:
 
     {
 	    yyMonthOrdinalIncr = (yyvsp[(2) - (3)].Number);
@@ -1809,7 +1823,7 @@ yyreduce:
 	;}
     break;
 
-  case 37:
+  case 38:
 
     {
 	    if ((yyvsp[(2) - (3)].Number) != HOUR( 7)) YYABORT;
@@ -1822,7 +1836,7 @@ yyreduce:
 	;}
     break;
 
-  case 38:
+  case 39:
 
     {
 	    if ((yyvsp[(2) - (7)].Number) != HOUR( 7)) YYABORT;
@@ -1835,7 +1849,7 @@ yyreduce:
 	;}
     break;
 
-  case 39:
+  case 40:
 
     {
 	    yyYear = (yyvsp[(1) - (2)].Number) / 10000;
@@ -1847,7 +1861,7 @@ yyreduce:
 	;}
     break;
 
-  case 40:
+  case 41:
 
     {
 	    /*
@@ -1863,7 +1877,7 @@ yyreduce:
 	;}
     break;
 
-  case 41:
+  case 42:
 
     {
 	    yyRelSeconds *= -1;
@@ -1872,60 +1886,52 @@ yyreduce:
 	;}
     break;
 
-  case 43:
+  case 44:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (3)].Number) * (yyvsp[(2) - (3)].Number) * (yyvsp[(3) - (3)].Number);
 	;}
     break;
 
-  case 44:
+  case 45:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (2)].Number) * (yyvsp[(2) - (2)].Number);
 	;}
     break;
 
-  case 45:
+  case 46:
 
     {
 	    *yyRelPointer += (yyvsp[(2) - (2)].Number);
 	;}
     break;
 
-  case 46:
+  case 47:
 
     {
 	    *yyRelPointer += (yyvsp[(2) - (3)].Number) * (yyvsp[(3) - (3)].Number);
 	;}
     break;
 
-  case 47:
+  case 48:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (1)].Number);
 	;}
     break;
 
-  case 48:
+  case 49:
 
     {
 	    (yyval.Number) = -1;
 	;}
     break;
 
-  case 49:
-
-    {
-	    (yyval.Number) =  1;
-	;}
-    break;
-
   case 50:
 
     {
-	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
-	    yyRelPointer = &yyRelSeconds;
+	    (yyval.Number) =  1;
 	;}
     break;
 
@@ -1933,7 +1939,7 @@ yyreduce:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
-	    yyRelPointer = &yyRelDay;
+	    yyRelPointer = &yyRelSeconds;
 	;}
     break;
 
@@ -1941,11 +1947,19 @@ yyreduce:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
-	    yyRelPointer = &yyRelMonth;
+	    yyRelPointer = &yyRelDay;
 	;}
     break;
 
   case 53:
+
+    {
+	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
+	    yyRelPointer = &yyRelMonth;
+	;}
+    break;
+
+  case 54:
 
     {
 	    if (yyHaveTime && yyHaveDate && !yyHaveRel) {
@@ -1965,14 +1979,14 @@ yyreduce:
 	;}
     break;
 
-  case 54:
+  case 55:
 
     {
 	    (yyval.Meridian) = MER24;
 	;}
     break;
 
-  case 55:
+  case 56:
 
     {
 	    (yyval.Meridian) = (yyvsp[(1) - (1)].Meridian);

--- a/generic/tclDate.c
+++ b/generic/tclDate.c
@@ -455,16 +455,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   79
+#define YYLAST   75
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  26
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  16
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  56
+#define YYNRULES  55
 /* YYNRULES -- Number of states.  */
-#define YYNSTATES  83
+#define YYNSTATES  79
 
 /* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
 #define YYUNDEFTOK  2
@@ -480,7 +480,7 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    25,    22,    21,    24,    23,     2,     2,
+       2,     2,     2,    25,    21,    23,    24,    22,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,    20,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -512,11 +512,11 @@ static const yytype_uint8 yytranslate[] =
 static const yytype_uint8 yyprhs[] =
 {
        0,     0,     3,     4,     7,     9,    11,    13,    15,    17,
-      19,    21,    23,    25,    28,    33,    39,    46,    54,    57,
-      59,    61,    63,    66,    69,    73,    76,    80,    86,    88,
-      94,   100,   103,   108,   111,   113,   117,   120,   124,   128,
-     136,   139,   144,   147,   149,   153,   156,   159,   163,   165,
-     167,   169,   171,   173,   175,   177,   178
+      19,    21,    23,    25,    28,    33,    40,    43,    45,    47,
+      50,    52,    55,    58,    62,    65,    69,    75,    77,    83,
+      89,    92,    97,   100,   102,   106,   109,   113,   117,   125,
+     128,   133,   136,   138,   142,   145,   148,   152,   154,   156,
+     158,   160,   162,   164,   166,   167
 };
 
 /* YYRHS -- A `-1'-separated list of the rules' RHS.  */
@@ -525,32 +525,31 @@ static const yytype_int8 yyrhs[] =
       27,     0,    -1,    -1,    27,    28,    -1,    29,    -1,    30,
       -1,    32,    -1,    33,    -1,    31,    -1,    36,    -1,    34,
       -1,    35,    -1,    40,    -1,    13,     7,    -1,    13,    20,
-      13,    41,    -1,    13,    20,    13,    21,    13,    -1,    13,
-      20,    13,    20,    13,    41,    -1,    13,    20,    13,    20,
-      13,    21,    13,    -1,    14,    16,    -1,    14,    -1,     5,
-      -1,     4,    -1,     4,    22,    -1,    13,     4,    -1,    38,
-      13,     4,    -1,    19,     4,    -1,    13,    23,    13,    -1,
-      13,    23,    13,    23,    13,    -1,    17,    -1,    13,    21,
-       8,    21,    13,    -1,    13,    21,    13,    21,    13,    -1,
-       8,    13,    -1,     8,    13,    22,    13,    -1,    13,     8,
-      -1,    15,    -1,    13,     8,    13,    -1,    19,     8,    -1,
-      19,    13,     8,    -1,    17,    14,    17,    -1,    17,    14,
-      13,    20,    13,    20,    13,    -1,    17,    17,    -1,    10,
-      13,    24,    13,    -1,    37,     3,    -1,    37,    -1,    38,
-      13,    39,    -1,    13,    39,    -1,    19,    39,    -1,    19,
-      13,    39,    -1,    39,    -1,    21,    -1,    25,    -1,    11,
-      -1,    18,    -1,     9,    -1,    13,    -1,    -1,     7,    -1
+      13,    41,    -1,    13,    20,    13,    20,    13,    41,    -1,
+      14,    16,    -1,    14,    -1,     5,    -1,    38,    13,    -1,
+       4,    -1,     4,    21,    -1,    13,     4,    -1,    38,    13,
+       4,    -1,    19,     4,    -1,    13,    22,    13,    -1,    13,
+      22,    13,    22,    13,    -1,    17,    -1,    13,    23,     8,
+      23,    13,    -1,    13,    23,    13,    23,    13,    -1,     8,
+      13,    -1,     8,    13,    21,    13,    -1,    13,     8,    -1,
+      15,    -1,    13,     8,    13,    -1,    19,     8,    -1,    19,
+      13,     8,    -1,    17,    14,    17,    -1,    17,    14,    13,
+      20,    13,    20,    13,    -1,    17,    17,    -1,    10,    13,
+      24,    13,    -1,    37,     3,    -1,    37,    -1,    38,    13,
+      39,    -1,    13,    39,    -1,    19,    39,    -1,    19,    13,
+      39,    -1,    39,    -1,    23,    -1,    25,    -1,    11,    -1,
+      18,    -1,     9,    -1,    13,    -1,    -1,     7,    -1
 };
 
 /* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
        0,   152,   152,   153,   156,   159,   162,   165,   168,   171,
-     174,   178,   183,   186,   192,   198,   206,   212,   223,   227,
-     231,   237,   241,   245,   249,   253,   259,   263,   268,   273,
-     278,   283,   287,   292,   296,   301,   308,   312,   318,   327,
-     336,   346,   360,   365,   368,   371,   374,   377,   380,   385,
-     388,   393,   397,   401,   407,   425,   428
+     174,   178,   183,   186,   192,   198,   206,   210,   214,   218,
+     224,   228,   232,   236,   240,   246,   250,   255,   260,   265,
+     270,   274,   279,   283,   288,   295,   299,   305,   314,   323,
+     333,   347,   352,   355,   358,   361,   364,   367,   372,   375,
+     380,   384,   388,   394,   412,   415
 };
 #endif
 
@@ -562,7 +561,7 @@ static const char *const yytname[] =
   "$end", "error", "$undefined", "tAGO", "tDAY", "tDAYZONE", "tID",
   "tMERIDIAN", "tMONTH", "tMONTH_UNIT", "tSTARDATE", "tSEC_UNIT",
   "tSNUMBER", "tUNUMBER", "tZONE", "tEPOCH", "tDST", "tISOBASE",
-  "tDAY_UNIT", "tNEXT", "':'", "'-'", "','", "'/'", "'.'", "'+'",
+  "tDAY_UNIT", "tNEXT", "':'", "','", "'/'", "'-'", "'.'", "'+'",
   "$accept", "spec", "item", "time", "zone", "day", "date", "ordMonth",
   "iso", "trek", "relspec", "relunits", "sign", "unit", "number",
   "o_merid", 0
@@ -576,7 +575,7 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-      58,    45,    44,    47,    46,    43
+      58,    44,    47,    45,    46,    43
 };
 # endif
 
@@ -584,22 +583,22 @@ static const yytype_uint16 yytoknum[] =
 static const yytype_uint8 yyr1[] =
 {
        0,    26,    27,    27,    28,    28,    28,    28,    28,    28,
-      28,    28,    28,    29,    29,    29,    29,    29,    30,    30,
-      30,    31,    31,    31,    31,    31,    32,    32,    32,    32,
-      32,    32,    32,    32,    32,    32,    33,    33,    34,    34,
-      34,    35,    36,    36,    37,    37,    37,    37,    37,    38,
-      38,    39,    39,    39,    40,    41,    41
+      28,    28,    28,    29,    29,    29,    30,    30,    30,    30,
+      31,    31,    31,    31,    31,    32,    32,    32,    32,    32,
+      32,    32,    32,    32,    32,    33,    33,    34,    34,    34,
+      35,    36,    36,    37,    37,    37,    37,    37,    38,    38,
+      39,    39,    39,    40,    41,    41
 };
 
 /* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
        0,     2,     0,     2,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     2,     4,     5,     6,     7,     2,     1,
-       1,     1,     2,     2,     3,     2,     3,     5,     1,     5,
-       5,     2,     4,     2,     1,     3,     2,     3,     3,     7,
-       2,     4,     2,     1,     3,     2,     2,     3,     1,     1,
-       1,     1,     1,     1,     1,     0,     1
+       1,     1,     1,     2,     4,     6,     2,     1,     1,     2,
+       1,     2,     2,     3,     2,     3,     5,     1,     5,     5,
+       2,     4,     2,     1,     3,     2,     3,     3,     7,     2,
+       4,     2,     1,     3,     2,     2,     3,     1,     1,     1,
+       1,     1,     1,     1,     0,     1
 };
 
 /* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
@@ -607,45 +606,43 @@ static const yytype_uint8 yyr2[] =
    means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       2,     0,     1,    21,    20,     0,    53,     0,    51,    54,
-      19,    34,    28,    52,     0,    49,    50,     3,     4,     5,
-       8,     6,     7,    10,    11,     9,    43,     0,    48,    12,
-      22,    31,     0,    23,    13,    33,     0,     0,     0,    45,
-      18,     0,    40,    25,    36,     0,    46,    42,     0,     0,
-       0,    35,    55,     0,     0,    26,     0,    38,    37,    47,
-      24,    44,    32,    41,    56,     0,     0,    14,     0,     0,
-       0,     0,    55,    15,    29,    30,    27,     0,     0,    16,
-       0,    17,    39
+       2,     0,     1,    20,    18,     0,    52,     0,    50,    53,
+      17,    33,    27,    51,     0,    48,    49,     3,     4,     5,
+       8,     6,     7,    10,    11,     9,    42,     0,    47,    12,
+      21,    30,     0,    22,    13,    32,     0,     0,     0,    44,
+      16,     0,    39,    24,    35,     0,    45,    41,    19,     0,
+       0,    34,    54,    25,     0,     0,     0,    37,    36,    46,
+      23,    43,    31,    40,    55,     0,    14,     0,     0,     0,
+       0,    54,    26,    28,    29,     0,    15,     0,    38
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
       -1,     1,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    67
+      25,    26,    27,    28,    29,    66
 };
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-#define YYPACT_NINF -22
+#define YYPACT_NINF -18
 static const yytype_int8 yypact[] =
 {
-     -22,     2,   -22,   -21,   -22,    -4,   -22,     1,   -22,    22,
-      18,   -22,     8,   -22,    40,   -22,   -22,   -22,   -22,   -22,
-     -22,   -22,   -22,   -22,   -22,   -22,    32,    28,   -22,   -22,
-     -22,    24,    26,   -22,   -22,    42,    47,    -5,    49,   -22,
-     -22,    15,   -22,   -22,   -22,    48,   -22,   -22,    43,    50,
-      51,   -22,    17,    44,    46,    45,    52,   -22,   -22,   -22,
-     -22,   -22,   -22,   -22,   -22,    56,    57,   -22,    58,    60,
-      61,    62,    -3,   -22,   -22,   -22,   -22,    59,    63,   -22,
-      64,   -22,   -22
+     -18,     2,   -18,   -17,   -18,    -4,   -18,    10,   -18,    22,
+       8,   -18,    18,   -18,    39,   -18,   -18,   -18,   -18,   -18,
+     -18,   -18,   -18,   -18,   -18,   -18,    25,    21,   -18,   -18,
+     -18,    16,    14,   -18,   -18,    28,    36,    41,    -5,   -18,
+     -18,     5,   -18,   -18,   -18,    47,   -18,   -18,    42,    46,
+      48,   -18,    -6,    40,    43,    44,    49,   -18,   -18,   -18,
+     -18,   -18,   -18,   -18,   -18,    50,   -18,    51,    55,    57,
+      58,    65,   -18,   -18,   -18,    53,   -18,    61,   -18
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,
-     -22,   -22,   -22,    -9,   -22,     6
+     -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,
+     -18,   -18,   -18,    -9,   -18,     4
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
@@ -655,26 +652,26 @@ static const yytype_int8 yypgoto[] =
 #define YYTABLE_NINF -1
 static const yytype_uint8 yytable[] =
 {
-      39,    30,     2,    53,    64,    46,     3,     4,    54,    31,
-       5,     6,     7,     8,    32,     9,    10,    11,    78,    12,
-      13,    14,    41,    15,    64,    42,    33,    16,    56,    34,
-      35,     6,    57,     8,    40,    47,    59,    65,    66,    61,
-      13,    48,    36,    37,    43,    38,    49,    60,    44,     6,
-      50,     8,     6,    45,     8,    51,    58,     6,    13,     8,
-      52,    13,    55,    62,    63,    68,    13,    69,    70,    72,
-      73,    74,    71,    75,    76,    77,    81,    82,    79,    80
+      39,    64,     2,    54,    30,    46,     3,     4,    55,    31,
+       5,     6,     7,     8,    65,     9,    10,    11,    56,    12,
+      13,    14,    57,    32,    40,    15,    33,    16,    47,    34,
+      35,     6,    41,     8,    48,    42,    59,    49,    50,    61,
+      13,    51,    36,    43,    37,    38,    60,    44,     6,    52,
+       8,     6,    45,     8,    53,    58,     6,    13,     8,    62,
+      13,    63,    67,    71,    72,    13,    68,    69,    73,    70,
+      74,    75,    64,    77,    78,    76
 };
 
 static const yytype_uint8 yycheck[] =
 {
-       9,    22,     0,     8,     7,    14,     4,     5,    13,    13,
-       8,     9,    10,    11,    13,    13,    14,    15,    21,    17,
-      18,    19,    14,    21,     7,    17,     4,    25,    13,     7,
-       8,     9,    17,    11,    16,     3,    45,    20,    21,    48,
-      18,    13,    20,    21,     4,    23,    22,     4,     8,     9,
-      24,    11,     9,    13,    11,    13,     8,     9,    18,    11,
-      13,    18,    13,    13,    13,    21,    18,    21,    23,    13,
-      13,    13,    20,    13,    13,    13,    13,    13,    72,    20
+       9,     7,     0,     8,    21,    14,     4,     5,    13,    13,
+       8,     9,    10,    11,    20,    13,    14,    15,    13,    17,
+      18,    19,    17,    13,    16,    23,     4,    25,     3,     7,
+       8,     9,    14,    11,    13,    17,    45,    21,    24,    48,
+      18,    13,    20,     4,    22,    23,     4,     8,     9,    13,
+      11,     9,    13,    11,    13,     8,     9,    18,    11,    13,
+      18,    13,    22,    13,    13,    18,    23,    23,    13,    20,
+      13,    13,     7,    20,    13,    71
 };
 
 /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
@@ -682,14 +679,13 @@ static const yytype_uint8 yycheck[] =
 static const yytype_uint8 yystos[] =
 {
        0,    27,     0,     4,     5,     8,     9,    10,    11,    13,
-      14,    15,    17,    18,    19,    21,    25,    28,    29,    30,
+      14,    15,    17,    18,    19,    23,    25,    28,    29,    30,
       31,    32,    33,    34,    35,    36,    37,    38,    39,    40,
-      22,    13,    13,     4,     7,     8,    20,    21,    23,    39,
-      16,    14,    17,     4,     8,    13,    39,     3,    13,    22,
-      24,    13,    13,     8,    13,    13,    13,    17,     8,    39,
-       4,    39,    13,    13,     7,    20,    21,    41,    21,    21,
-      23,    20,    13,    13,    13,    13,    13,    13,    21,    41,
-      20,    13,    13
+      21,    13,    13,     4,     7,     8,    20,    22,    23,    39,
+      16,    14,    17,     4,     8,    13,    39,     3,    13,    21,
+      24,    13,    13,    13,     8,    13,    13,    17,     8,    39,
+       4,    39,    13,    13,     7,    20,    41,    22,    23,    23,
+      20,    13,    13,    13,    13,    13,    41,    20,    13
 };
 
 #define yyerrok		(yyerrstatus = 0)
@@ -1631,18 +1627,6 @@ yyreduce:
   case 15:
 
     {
-	    yyHour = (yyvsp[(1) - (5)].Number);
-	    yyMinutes = (yyvsp[(3) - (5)].Number);
-	    yyMeridian = MER24;
-	    yyDSTmode = DSToff;
-	    yyTimezone = ((yyvsp[(5) - (5)].Number) % 100 + ((yyvsp[(5) - (5)].Number) / 100) * 60);
-	    ++yyHaveZone;
-	;}
-    break;
-
-  case 16:
-
-    {
 	    yyHour = (yyvsp[(1) - (6)].Number);
 	    yyMinutes = (yyvsp[(3) - (6)].Number);
 	    yySeconds = (yyvsp[(5) - (6)].Number);
@@ -1650,20 +1634,7 @@ yyreduce:
 	;}
     break;
 
-  case 17:
-
-    {
-	    yyHour = (yyvsp[(1) - (7)].Number);
-	    yyMinutes = (yyvsp[(3) - (7)].Number);
-	    yySeconds = (yyvsp[(5) - (7)].Number);
-	    yyMeridian = MER24;
-	    yyDSTmode = DSToff;
-	    yyTimezone = ((yyvsp[(7) - (7)].Number) % 100 + ((yyvsp[(7) - (7)].Number) / 100) * 60);
-	    ++yyHaveZone;
-	;}
-    break;
-
-  case 18:
+  case 16:
 
     {
 	    yyTimezone = (yyvsp[(1) - (2)].Number);
@@ -1671,7 +1642,7 @@ yyreduce:
 	;}
     break;
 
-  case 19:
+  case 17:
 
     {
 	    yyTimezone = (yyvsp[(1) - (1)].Number);
@@ -1679,7 +1650,7 @@ yyreduce:
 	;}
     break;
 
-  case 20:
+  case 18:
 
     {
 	    yyTimezone = (yyvsp[(1) - (1)].Number);
@@ -1687,7 +1658,15 @@ yyreduce:
 	;}
     break;
 
-  case 21:
+  case 19:
+
+    {
+	    yyTimezone = -(yyvsp[(1) - (2)].Number)*((yyvsp[(2) - (2)].Number) % 100 + ((yyvsp[(2) - (2)].Number) / 100) * 60);
+	    yyDSTmode = DSToff;
+	;}
+    break;
+
+  case 20:
 
     {
 	    yyDayOrdinal = 1;
@@ -1695,7 +1674,7 @@ yyreduce:
 	;}
     break;
 
-  case 22:
+  case 21:
 
     {
 	    yyDayOrdinal = 1;
@@ -1703,7 +1682,7 @@ yyreduce:
 	;}
     break;
 
-  case 23:
+  case 22:
 
     {
 	    yyDayOrdinal = (yyvsp[(1) - (2)].Number);
@@ -1711,7 +1690,7 @@ yyreduce:
 	;}
     break;
 
-  case 24:
+  case 23:
 
     {
 	    yyDayOrdinal = (yyvsp[(1) - (3)].Number) * (yyvsp[(2) - (3)].Number);
@@ -1719,7 +1698,7 @@ yyreduce:
 	;}
     break;
 
-  case 25:
+  case 24:
 
     {
 	    yyDayOrdinal = 2;
@@ -1727,7 +1706,7 @@ yyreduce:
 	;}
     break;
 
-  case 26:
+  case 25:
 
     {
 	    yyMonth = (yyvsp[(1) - (3)].Number);
@@ -1735,7 +1714,7 @@ yyreduce:
 	;}
     break;
 
-  case 27:
+  case 26:
 
     {
 	    yyMonth = (yyvsp[(1) - (5)].Number);
@@ -1744,7 +1723,7 @@ yyreduce:
 	;}
     break;
 
-  case 28:
+  case 27:
 
     {
 	    yyYear = (yyvsp[(1) - (1)].Number) / 10000;
@@ -1753,7 +1732,7 @@ yyreduce:
 	;}
     break;
 
-  case 29:
+  case 28:
 
     {
 	    yyDay = (yyvsp[(1) - (5)].Number);
@@ -1762,7 +1741,7 @@ yyreduce:
 	;}
     break;
 
-  case 30:
+  case 29:
 
     {
 	    yyMonth = (yyvsp[(3) - (5)].Number);
@@ -1771,7 +1750,7 @@ yyreduce:
 	;}
     break;
 
-  case 31:
+  case 30:
 
     {
 	    yyMonth = (yyvsp[(1) - (2)].Number);
@@ -1779,7 +1758,7 @@ yyreduce:
 	;}
     break;
 
-  case 32:
+  case 31:
 
     {
 	    yyMonth = (yyvsp[(1) - (4)].Number);
@@ -1788,7 +1767,7 @@ yyreduce:
 	;}
     break;
 
-  case 33:
+  case 32:
 
     {
 	    yyMonth = (yyvsp[(2) - (2)].Number);
@@ -1796,7 +1775,7 @@ yyreduce:
 	;}
     break;
 
-  case 34:
+  case 33:
 
     {
 	    yyMonth = 1;
@@ -1805,7 +1784,7 @@ yyreduce:
 	;}
     break;
 
-  case 35:
+  case 34:
 
     {
 	    yyMonth = (yyvsp[(2) - (3)].Number);
@@ -1814,7 +1793,7 @@ yyreduce:
 	;}
     break;
 
-  case 36:
+  case 35:
 
     {
 	    yyMonthOrdinalIncr = 1;
@@ -1822,7 +1801,7 @@ yyreduce:
 	;}
     break;
 
-  case 37:
+  case 36:
 
     {
 	    yyMonthOrdinalIncr = (yyvsp[(2) - (3)].Number);
@@ -1830,7 +1809,7 @@ yyreduce:
 	;}
     break;
 
-  case 38:
+  case 37:
 
     {
 	    if ((yyvsp[(2) - (3)].Number) != HOUR( 7)) YYABORT;
@@ -1843,7 +1822,7 @@ yyreduce:
 	;}
     break;
 
-  case 39:
+  case 38:
 
     {
 	    if ((yyvsp[(2) - (7)].Number) != HOUR( 7)) YYABORT;
@@ -1856,7 +1835,7 @@ yyreduce:
 	;}
     break;
 
-  case 40:
+  case 39:
 
     {
 	    yyYear = (yyvsp[(1) - (2)].Number) / 10000;
@@ -1868,7 +1847,7 @@ yyreduce:
 	;}
     break;
 
-  case 41:
+  case 40:
 
     {
 	    /*
@@ -1884,7 +1863,7 @@ yyreduce:
 	;}
     break;
 
-  case 42:
+  case 41:
 
     {
 	    yyRelSeconds *= -1;
@@ -1893,56 +1872,56 @@ yyreduce:
 	;}
     break;
 
-  case 44:
+  case 43:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (3)].Number) * (yyvsp[(2) - (3)].Number) * (yyvsp[(3) - (3)].Number);
 	;}
     break;
 
-  case 45:
+  case 44:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (2)].Number) * (yyvsp[(2) - (2)].Number);
 	;}
     break;
 
-  case 46:
+  case 45:
 
     {
 	    *yyRelPointer += (yyvsp[(2) - (2)].Number);
 	;}
     break;
 
-  case 47:
+  case 46:
 
     {
 	    *yyRelPointer += (yyvsp[(2) - (3)].Number) * (yyvsp[(3) - (3)].Number);
 	;}
     break;
 
-  case 48:
+  case 47:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (1)].Number);
 	;}
     break;
 
-  case 49:
+  case 48:
 
     {
 	    (yyval.Number) = -1;
 	;}
     break;
 
-  case 50:
+  case 49:
 
     {
 	    (yyval.Number) =  1;
 	;}
     break;
 
-  case 51:
+  case 50:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
@@ -1950,7 +1929,7 @@ yyreduce:
 	;}
     break;
 
-  case 52:
+  case 51:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
@@ -1958,7 +1937,7 @@ yyreduce:
 	;}
     break;
 
-  case 53:
+  case 52:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
@@ -1966,7 +1945,7 @@ yyreduce:
 	;}
     break;
 
-  case 54:
+  case 53:
 
     {
 	    if (yyHaveTime && yyHaveDate && !yyHaveRel) {
@@ -1986,14 +1965,14 @@ yyreduce:
 	;}
     break;
 
-  case 55:
+  case 54:
 
     {
 	    (yyval.Meridian) = MER24;
 	;}
     break;
 
-  case 56:
+  case 55:
 
     {
 	    (yyval.Meridian) = (yyvsp[(1) - (1)].Meridian);

--- a/generic/tclDate.c
+++ b/generic/tclDate.c
@@ -99,6 +99,10 @@
 #pragma warning( disable : 4102 )
 #endif /* _MSC_VER */
 
+#if 0
+#define YYDEBUG 1
+#endif
+
 /*
  * yyparse will accept a 'struct DateInfo' as its parameter; that's where the
  * parsed fields will be returned.
@@ -179,14 +183,16 @@ typedef enum _DSTMODE {
      tMONTH_UNIT = 264,
      tSTARDATE = 265,
      tSEC_UNIT = 266,
-     tSNUMBER = 267,
-     tUNUMBER = 268,
-     tZONE = 269,
-     tEPOCH = 270,
-     tDST = 271,
-     tISOBASE = 272,
-     tDAY_UNIT = 273,
-     tNEXT = 274
+     tUNUMBER = 267,
+     tZONE = 268,
+     tZONEwO4 = 269,
+     tZONEwO2 = 270,
+     tEPOCH = 271,
+     tDST = 272,
+     tISOBASE = 273,
+     tDAY_UNIT = 274,
+     tNEXT = 275,
+     SP = 276
    };
 #endif
 
@@ -455,20 +461,20 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   80
+#define YYLAST   116
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  26
+#define YYNTOKENS  28
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  16
+#define YYNNTS  18
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  56
+#define YYNRULES  66
 /* YYNRULES -- Number of states.  */
-#define YYNSTATES  81
+#define YYNSTATES  106
 
 /* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   274
+#define YYMAXUTOK   276
 
 #define YYTRANSLATE(YYX)						\
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
@@ -480,8 +486,8 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    25,    21,    23,    24,    22,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,    20,     2,
+       2,     2,     2,    27,    23,    25,    26,    24,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,    22,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -503,7 +509,7 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19
+      15,    16,    17,    18,    19,    20,    21
 };
 
 #if YYDEBUG
@@ -511,46 +517,52 @@ static const yytype_uint8 yytranslate[] =
    YYRHS.  */
 static const yytype_uint8 yyprhs[] =
 {
-       0,     0,     3,     4,     7,     9,    11,    13,    15,    17,
-      19,    21,    23,    25,    28,    33,    40,    43,    45,    47,
-      50,    54,    56,    59,    62,    66,    69,    73,    79,    81,
-      87,    93,    96,   101,   104,   106,   110,   113,   117,   121,
-     129,   132,   137,   140,   142,   146,   149,   152,   156,   158,
-     160,   162,   164,   166,   168,   170,   171
+       0,     0,     3,     4,     7,    11,    13,    15,    17,    19,
+      21,    23,    25,    27,    29,    32,    37,    44,    47,    49,
+      51,    55,    59,    62,    64,    67,    69,    72,    75,    80,
+      84,    87,    91,    97,    99,   105,   111,   114,   119,   122,
+     124,   128,   131,   135,   139,   142,   150,   158,   162,   167,
+     170,   172,   177,   181,   184,   187,   191,   193,   195,   197,
+     199,   201,   203,   205,   207,   209,   210
 };
 
 /* YYRHS -- A `-1'-separated list of the rules' RHS.  */
 static const yytype_int8 yyrhs[] =
 {
-      27,     0,    -1,    -1,    27,    28,    -1,    29,    -1,    30,
-      -1,    32,    -1,    33,    -1,    31,    -1,    36,    -1,    34,
-      -1,    35,    -1,    40,    -1,    13,     7,    -1,    13,    20,
-      13,    41,    -1,    13,    20,    13,    20,    13,    41,    -1,
-      14,    16,    -1,    14,    -1,     5,    -1,    38,    13,    -1,
-      14,    38,    13,    -1,     4,    -1,     4,    21,    -1,    13,
-       4,    -1,    38,    13,     4,    -1,    19,     4,    -1,    13,
-      22,    13,    -1,    13,    22,    13,    22,    13,    -1,    17,
-      -1,    13,    23,     8,    23,    13,    -1,    13,    23,    13,
-      23,    13,    -1,     8,    13,    -1,     8,    13,    21,    13,
-      -1,    13,     8,    -1,    15,    -1,    13,     8,    13,    -1,
-      19,     8,    -1,    19,    13,     8,    -1,    17,    14,    17,
-      -1,    17,    14,    13,    20,    13,    20,    13,    -1,    17,
-      17,    -1,    10,    13,    24,    13,    -1,    37,     3,    -1,
-      37,    -1,    38,    13,    39,    -1,    13,    39,    -1,    19,
-      39,    -1,    19,    13,    39,    -1,    39,    -1,    23,    -1,
-      25,    -1,    11,    -1,    18,    -1,     9,    -1,    13,    -1,
-      -1,     7,    -1
+      29,     0,    -1,    -1,    29,    30,    -1,    29,    21,    30,
+      -1,    31,    -1,    32,    -1,    35,    -1,    36,    -1,    34,
+      -1,    39,    -1,    37,    -1,    38,    -1,    44,    -1,    12,
+       7,    -1,    12,    22,    12,    45,    -1,    12,    22,    12,
+      22,    12,    45,    -1,    13,    17,    -1,    13,    -1,     5,
+      -1,    14,    41,    43,    -1,    15,    41,    43,    -1,    41,
+      43,    -1,    23,    -1,    23,    21,    -1,     4,    -1,     4,
+      33,    -1,    12,     4,    -1,    41,    21,    12,     4,    -1,
+      41,    12,     4,    -1,    20,     4,    -1,    12,    24,    12,
+      -1,    12,    24,    12,    24,    12,    -1,    18,    -1,    12,
+      25,     8,    25,    12,    -1,    12,    25,    12,    25,    12,
+      -1,     8,    12,    -1,     8,    12,    33,    12,    -1,    12,
+       8,    -1,    16,    -1,    12,     8,    12,    -1,    20,     8,
+      -1,    20,    12,     8,    -1,    18,    13,    18,    -1,    18,
+      18,    -1,    18,    21,    12,    22,    12,    22,    12,    -1,
+      18,    13,    12,    22,    12,    22,    12,    -1,    18,    21,
+      18,    -1,    10,    43,    26,    12,    -1,    40,     3,    -1,
+      40,    -1,    41,    21,    43,    42,    -1,    41,    43,    42,
+      -1,    43,    42,    -1,    20,    42,    -1,    20,    43,    42,
+      -1,    42,    -1,    25,    -1,    27,    -1,    11,    -1,    19,
+      -1,     9,    -1,    12,    -1,    18,    -1,    43,    -1,    -1,
+       7,    -1
 };
 
 /* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   152,   152,   153,   156,   159,   162,   165,   168,   171,
-     174,   178,   183,   186,   192,   198,   206,   210,   214,   218,
-     222,   228,   232,   236,   240,   244,   250,   254,   259,   264,
-     269,   274,   278,   283,   287,   292,   299,   303,   309,   318,
-     327,   337,   351,   356,   359,   362,   365,   368,   371,   376,
-     379,   384,   388,   392,   398,   416,   419
+       0,   160,   160,   161,   162,   165,   168,   171,   174,   177,
+     180,   183,   187,   192,   195,   201,   207,   215,   219,   223,
+     227,   231,   235,   241,   242,   245,   249,   253,   257,   261,
+     265,   271,   275,   280,   285,   290,   295,   299,   304,   308,
+     313,   320,   324,   330,   339,   347,   355,   364,   374,   388,
+     393,   396,   399,   402,   405,   408,   411,   416,   419,   424,
+     428,   432,   438,   441,   446,   464,   467
 };
 #endif
 
@@ -561,11 +573,11 @@ static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "tAGO", "tDAY", "tDAYZONE", "tID",
   "tMERIDIAN", "tMONTH", "tMONTH_UNIT", "tSTARDATE", "tSEC_UNIT",
-  "tSNUMBER", "tUNUMBER", "tZONE", "tEPOCH", "tDST", "tISOBASE",
-  "tDAY_UNIT", "tNEXT", "':'", "','", "'/'", "'-'", "'.'", "'+'",
-  "$accept", "spec", "item", "time", "zone", "day", "date", "ordMonth",
-  "iso", "trek", "relspec", "relunits", "sign", "unit", "number",
-  "o_merid", 0
+  "tUNUMBER", "tZONE", "tZONEwO4", "tZONEwO2", "tEPOCH", "tDST",
+  "tISOBASE", "tDAY_UNIT", "tNEXT", "SP", "':'", "','", "'/'", "'-'",
+  "'.'", "'+'", "$accept", "spec", "item", "time", "zone", "comma", "day",
+  "date", "ordMonth", "iso", "trek", "relspec", "relunits", "sign", "unit",
+  "INTNUM", "number", "o_merid", 0
 };
 #endif
 
@@ -576,29 +588,31 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-      58,    44,    47,    45,    46,    43
+     275,   276,    58,    44,    47,    45,    46,    43
 };
 # endif
 
 /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    26,    27,    27,    28,    28,    28,    28,    28,    28,
-      28,    28,    28,    29,    29,    29,    30,    30,    30,    30,
-      30,    31,    31,    31,    31,    31,    32,    32,    32,    32,
-      32,    32,    32,    32,    32,    32,    33,    33,    34,    34,
-      34,    35,    36,    36,    37,    37,    37,    37,    37,    38,
-      38,    39,    39,    39,    40,    41,    41
+       0,    28,    29,    29,    29,    30,    30,    30,    30,    30,
+      30,    30,    30,    30,    31,    31,    31,    32,    32,    32,
+      32,    32,    32,    33,    33,    34,    34,    34,    34,    34,
+      34,    35,    35,    35,    35,    35,    35,    35,    35,    35,
+      35,    36,    36,    37,    37,    37,    37,    37,    38,    39,
+      39,    40,    40,    40,    40,    40,    40,    41,    41,    42,
+      42,    42,    43,    43,    44,    45,    45
 };
 
 /* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
-       0,     2,     0,     2,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     2,     4,     6,     2,     1,     1,     2,
-       3,     1,     2,     2,     3,     2,     3,     5,     1,     5,
-       5,     2,     4,     2,     1,     3,     2,     3,     3,     7,
-       2,     4,     2,     1,     3,     2,     2,     3,     1,     1,
+       0,     2,     0,     2,     3,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     2,     4,     6,     2,     1,     1,
+       3,     3,     2,     1,     2,     1,     2,     2,     4,     3,
+       2,     3,     5,     1,     5,     5,     2,     4,     2,     1,
+       3,     2,     3,     3,     2,     7,     7,     3,     4,     2,
+       1,     4,     3,     2,     2,     3,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     0,     1
 };
 
@@ -607,45 +621,49 @@ static const yytype_uint8 yyr2[] =
    means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       2,     0,     1,    21,    18,     0,    53,     0,    51,    54,
-      17,    34,    28,    52,     0,    49,    50,     3,     4,     5,
-       8,     6,     7,    10,    11,     9,    43,     0,    48,    12,
-      22,    31,     0,    23,    13,    33,     0,     0,     0,    45,
-      16,     0,     0,    40,    25,    36,     0,    46,    42,    19,
-       0,     0,    35,    55,    26,     0,     0,    20,     0,    38,
-      37,    47,    24,    44,    32,    41,    56,     0,    14,     0,
-       0,     0,     0,    55,    27,    29,    30,     0,    15,     0,
-      39
+       2,     0,     1,    25,    19,     0,    61,     0,    59,    62,
+      18,     0,     0,    39,    33,    60,     0,     0,    57,    58,
+       3,     5,     6,     9,     7,     8,    11,    12,    10,    50,
+       0,    56,    64,    13,    23,    26,    36,    62,    63,     0,
+      27,    14,    38,     0,     0,     0,    17,     0,     0,     0,
+      44,     0,    30,    41,    62,    54,     0,     4,    49,    62,
+       0,    22,    53,    24,     0,     0,    40,    65,    31,     0,
+       0,    20,    21,     0,    43,     0,    47,    42,    55,    29,
+      62,     0,    52,    37,    48,    66,     0,    15,     0,     0,
+       0,     0,     0,    28,    51,    65,    32,    34,    35,     0,
+       0,    16,     0,     0,    46,    45
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,     1,    17,    18,    19,    20,    21,    22,    23,    24,
-      25,    26,    27,    28,    29,    68
+      -1,     1,    20,    21,    22,    35,    23,    24,    25,    26,
+      27,    28,    29,    30,    31,    32,    33,    87
 };
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-#define YYPACT_NINF -18
+#define YYPACT_NINF -17
 static const yytype_int8 yypact[] =
 {
-     -18,     2,   -18,   -17,   -18,    -4,   -18,    11,   -18,    24,
-      35,   -18,     9,   -18,    30,   -18,   -18,   -18,   -18,   -18,
-     -18,   -18,   -18,   -18,   -18,   -18,    26,    17,   -18,   -18,
-     -18,    15,    25,   -18,   -18,    42,    44,    48,    -5,   -18,
-     -18,    49,     5,   -18,   -18,   -18,    45,   -18,   -18,    41,
-      51,    52,   -18,    -6,    46,    43,    47,   -18,    53,   -18,
-     -18,   -18,   -18,   -18,   -18,   -18,   -18,    54,   -18,    56,
-      58,    59,    61,    68,   -18,   -18,   -18,    57,   -18,    63,
-     -18
+     -17,    48,   -17,    -9,   -17,    34,   -17,    19,   -17,    -2,
+      30,   -10,   -10,   -17,     8,   -17,     0,    72,   -17,   -17,
+     -17,   -17,   -17,   -17,   -17,   -17,   -17,   -17,   -17,    52,
+      18,   -17,    16,   -17,    49,   -17,    -9,   -17,   -17,    25,
+     -17,   -17,    59,    60,    62,    -5,   -17,    19,    19,    20,
+     -17,    31,   -17,   -17,    70,   -17,    16,   -17,   -17,    75,
+      32,    16,   -17,   -17,    77,    81,   -17,     6,    71,    69,
+      73,   -17,   -17,    74,   -17,    78,   -17,   -17,   -17,   -17,
+      97,    16,   -17,   -17,   -17,   -17,    90,   -17,    91,    92,
+      93,    94,    95,   -17,   -17,   101,   -17,   -17,   -17,    87,
+      88,   -17,    99,   100,   -17,   -17
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,   -18,
-     -18,   -18,    69,    -9,   -18,     7
+     -17,   -17,    96,   -17,   -17,    79,   -17,   -17,   -17,   -17,
+     -17,   -17,   -17,    22,   -16,    -6,   -17,    21
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
@@ -655,43 +673,51 @@ static const yytype_int8 yypgoto[] =
 #define YYTABLE_NINF -1
 static const yytype_uint8 yytable[] =
 {
-      39,    66,     2,    55,    30,    47,     3,     4,    56,    31,
-       5,     6,     7,     8,    67,     9,    10,    11,    58,    12,
-      13,    14,    59,    42,    32,    15,    43,    16,    33,    48,
-      49,    34,    35,     6,    44,     8,    50,    61,    45,     6,
-      63,     8,    13,    46,    36,    62,    37,    38,    13,    51,
-       6,    40,     8,    60,     6,    52,     8,    53,    15,    13,
-      16,    54,    57,    13,    64,    65,    70,    73,    69,    74,
-      71,    75,    76,    72,    77,    66,    80,    79,     0,    41,
-      78
+      55,    39,    40,    69,    52,    41,    42,    70,    53,     6,
+      56,     8,    54,    85,    34,    18,    62,    19,    38,    15,
+      43,    49,    44,    45,    61,     6,    50,     8,    86,    51,
+      59,    37,    73,    47,    48,    15,    38,    38,    74,    60,
+      78,    71,    72,    75,    80,    82,    36,    46,     2,    76,
+      38,    65,     3,     4,    81,    58,     5,     6,     7,     8,
+       9,    10,    11,    12,    13,    94,    14,    15,    16,    17,
+      63,    66,    67,    18,    68,    19,     3,     4,    77,    79,
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    83,
+      14,    15,    16,    84,    89,    88,    91,    18,    90,    19,
+      92,    93,    95,    96,    97,    98,    99,   100,    85,   102,
+     103,   104,   105,    57,     0,    64,   101
 };
 
 static const yytype_int8 yycheck[] =
 {
-       9,     7,     0,     8,    21,    14,     4,     5,    13,    13,
-       8,     9,    10,    11,    20,    13,    14,    15,    13,    17,
-      18,    19,    17,    14,    13,    23,    17,    25,     4,     3,
-      13,     7,     8,     9,     4,    11,    21,    46,     8,     9,
-      49,    11,    18,    13,    20,     4,    22,    23,    18,    24,
-       9,    16,    11,     8,     9,    13,    11,    13,    23,    18,
-      25,    13,    13,    18,    13,    13,    23,    13,    22,    13,
-      23,    13,    13,    20,    13,     7,    13,    20,    -1,    10,
-      73
+      16,     7,     4,     8,     4,     7,     8,    12,     8,     9,
+      16,    11,    12,     7,    23,    25,    32,    27,    18,    19,
+      22,    13,    24,    25,    30,     9,    18,    11,    22,    21,
+      12,    12,    12,    11,    12,    19,    18,    18,    18,    21,
+      56,    47,    48,    12,    12,    61,    12,    17,     0,    18,
+      18,    26,     4,     5,    60,     3,     8,     9,    10,    11,
+      12,    13,    14,    15,    16,    81,    18,    19,    20,    21,
+      21,    12,    12,    25,    12,    27,     4,     5,     8,     4,
+       8,     9,    10,    11,    12,    13,    14,    15,    16,    12,
+      18,    19,    20,    12,    25,    24,    22,    25,    25,    27,
+      22,     4,    12,    12,    12,    12,    12,    12,     7,    22,
+      22,    12,    12,    17,    -1,    36,    95
 };
 
 /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
    symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    27,     0,     4,     5,     8,     9,    10,    11,    13,
-      14,    15,    17,    18,    19,    23,    25,    28,    29,    30,
-      31,    32,    33,    34,    35,    36,    37,    38,    39,    40,
-      21,    13,    13,     4,     7,     8,    20,    22,    23,    39,
-      16,    38,    14,    17,     4,     8,    13,    39,     3,    13,
-      21,    24,    13,    13,    13,     8,    13,    13,    13,    17,
-       8,    39,     4,    39,    13,    13,     7,    20,    41,    22,
-      23,    23,    20,    13,    13,    13,    13,    13,    41,    20,
-      13
+       0,    29,     0,     4,     5,     8,     9,    10,    11,    12,
+      13,    14,    15,    16,    18,    19,    20,    21,    25,    27,
+      30,    31,    32,    34,    35,    36,    37,    38,    39,    40,
+      41,    42,    43,    44,    23,    33,    12,    12,    18,    43,
+       4,     7,     8,    22,    24,    25,    17,    41,    41,    13,
+      18,    21,     4,     8,    12,    42,    43,    30,     3,    12,
+      21,    43,    42,    21,    33,    26,    12,    12,    12,     8,
+      12,    43,    43,    12,    18,    12,    18,     8,    42,     4,
+      12,    43,    42,    12,    12,     7,    22,    45,    24,    25,
+      25,    22,    22,     4,    42,    12,    12,    12,    12,    12,
+      12,    45,    22,    22,    12,    12
 };
 
 #define yyerrok		(yyerrstatus = 0)
@@ -1551,53 +1577,45 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 4:
+        case 5:
 
     {
 	    yyHaveTime++;
-	;}
-    break;
-
-  case 5:
-
-    {
-	    yyHaveZone++;
 	;}
     break;
 
   case 6:
 
     {
-	    yyHaveDate++;
+	    yyHaveZone++;
 	;}
     break;
 
   case 7:
 
     {
-	    yyHaveOrdinalMonth++;
+	    yyHaveDate++;
 	;}
     break;
 
   case 8:
 
     {
-	    yyHaveDay++;
+	    yyHaveOrdinalMonth++;
 	;}
     break;
 
   case 9:
 
     {
-	    yyHaveRel++;
+	    yyHaveDay++;
 	;}
     break;
 
   case 10:
 
     {
-	    yyHaveTime++;
-	    yyHaveDate++;
+	    yyHaveRel++;
 	;}
     break;
 
@@ -1606,11 +1624,19 @@ yyreduce:
     {
 	    yyHaveTime++;
 	    yyHaveDate++;
+	;}
+    break;
+
+  case 12:
+
+    {
+	    yyHaveTime++;
+	    yyHaveDate++;
 	    yyHaveRel++;
 	;}
     break;
 
-  case 13:
+  case 14:
 
     {
 	    yyHour = (yyvsp[(1) - (2)].Number);
@@ -1620,7 +1646,7 @@ yyreduce:
 	;}
     break;
 
-  case 14:
+  case 15:
 
     {
 	    yyHour = (yyvsp[(1) - (4)].Number);
@@ -1630,7 +1656,7 @@ yyreduce:
 	;}
     break;
 
-  case 15:
+  case 16:
 
     {
 	    yyHour = (yyvsp[(1) - (6)].Number);
@@ -1640,7 +1666,7 @@ yyreduce:
 	;}
     break;
 
-  case 16:
+  case 17:
 
     {
 	    yyTimezone = (yyvsp[(1) - (2)].Number);
@@ -1648,7 +1674,7 @@ yyreduce:
 	;}
     break;
 
-  case 17:
+  case 18:
 
     {
 	    yyTimezone = (yyvsp[(1) - (1)].Number);
@@ -1656,7 +1682,7 @@ yyreduce:
 	;}
     break;
 
-  case 18:
+  case 19:
 
     {
 	    yyTimezone = (yyvsp[(1) - (1)].Number);
@@ -1664,17 +1690,9 @@ yyreduce:
 	;}
     break;
 
-  case 19:
-
-    {
-	    yyTimezone = -(yyvsp[(1) - (2)].Number)*((yyvsp[(2) - (2)].Number) % 100 + ((yyvsp[(2) - (2)].Number) / 100) * 60);
-	    yyDSTmode = DSToff;
-	;}
-    break;
-
   case 20:
 
-    {
+    { /* GMT+0100, GMT-1000, etc. */
 	    yyTimezone = (yyvsp[(1) - (3)].Number) - (yyvsp[(2) - (3)].Number)*((yyvsp[(3) - (3)].Number) % 100 + ((yyvsp[(3) - (3)].Number) / 100) * 60);
 	    yyDSTmode = DSToff;
 	;}
@@ -1682,13 +1700,29 @@ yyreduce:
 
   case 21:
 
+    { /* GMT+1, GMT-10, etc. */
+	    yyTimezone = (yyvsp[(1) - (3)].Number) - (yyvsp[(2) - (3)].Number)*((yyvsp[(3) - (3)].Number) * 60);
+	    yyDSTmode = DSToff;
+	;}
+    break;
+
+  case 22:
+
+    { /* +0100, -0100 */
+	    yyTimezone = -(yyvsp[(1) - (2)].Number)*((yyvsp[(2) - (2)].Number) % 100 + ((yyvsp[(2) - (2)].Number) / 100) * 60);
+	    yyDSTmode = DSToff;
+	;}
+    break;
+
+  case 25:
+
     {
 	    yyDayOrdinal = 1;
 	    yyDayNumber = (yyvsp[(1) - (1)].Number);
 	;}
     break;
 
-  case 22:
+  case 26:
 
     {
 	    yyDayOrdinal = 1;
@@ -1696,7 +1730,7 @@ yyreduce:
 	;}
     break;
 
-  case 23:
+  case 27:
 
     {
 	    yyDayOrdinal = (yyvsp[(1) - (2)].Number);
@@ -1704,7 +1738,15 @@ yyreduce:
 	;}
     break;
 
-  case 24:
+  case 28:
+
+    {
+	    yyDayOrdinal = (yyvsp[(1) - (4)].Number) * (yyvsp[(3) - (4)].Number);
+	    yyDayNumber = (yyvsp[(4) - (4)].Number);
+	;}
+    break;
+
+  case 29:
 
     {
 	    yyDayOrdinal = (yyvsp[(1) - (3)].Number) * (yyvsp[(2) - (3)].Number);
@@ -1712,7 +1754,7 @@ yyreduce:
 	;}
     break;
 
-  case 25:
+  case 30:
 
     {
 	    yyDayOrdinal = 2;
@@ -1720,7 +1762,7 @@ yyreduce:
 	;}
     break;
 
-  case 26:
+  case 31:
 
     {
 	    yyMonth = (yyvsp[(1) - (3)].Number);
@@ -1728,7 +1770,7 @@ yyreduce:
 	;}
     break;
 
-  case 27:
+  case 32:
 
     {
 	    yyMonth = (yyvsp[(1) - (5)].Number);
@@ -1737,7 +1779,7 @@ yyreduce:
 	;}
     break;
 
-  case 28:
+  case 33:
 
     {
 	    yyYear = (yyvsp[(1) - (1)].Number) / 10000;
@@ -1746,7 +1788,7 @@ yyreduce:
 	;}
     break;
 
-  case 29:
+  case 34:
 
     {
 	    yyDay = (yyvsp[(1) - (5)].Number);
@@ -1755,7 +1797,7 @@ yyreduce:
 	;}
     break;
 
-  case 30:
+  case 35:
 
     {
 	    yyMonth = (yyvsp[(3) - (5)].Number);
@@ -1764,7 +1806,7 @@ yyreduce:
 	;}
     break;
 
-  case 31:
+  case 36:
 
     {
 	    yyMonth = (yyvsp[(1) - (2)].Number);
@@ -1772,7 +1814,7 @@ yyreduce:
 	;}
     break;
 
-  case 32:
+  case 37:
 
     {
 	    yyMonth = (yyvsp[(1) - (4)].Number);
@@ -1781,7 +1823,7 @@ yyreduce:
 	;}
     break;
 
-  case 33:
+  case 38:
 
     {
 	    yyMonth = (yyvsp[(2) - (2)].Number);
@@ -1789,7 +1831,7 @@ yyreduce:
 	;}
     break;
 
-  case 34:
+  case 39:
 
     {
 	    yyMonth = 1;
@@ -1798,7 +1840,7 @@ yyreduce:
 	;}
     break;
 
-  case 35:
+  case 40:
 
     {
 	    yyMonth = (yyvsp[(2) - (3)].Number);
@@ -1807,7 +1849,7 @@ yyreduce:
 	;}
     break;
 
-  case 36:
+  case 41:
 
     {
 	    yyMonthOrdinalIncr = 1;
@@ -1815,7 +1857,7 @@ yyreduce:
 	;}
     break;
 
-  case 37:
+  case 42:
 
     {
 	    yyMonthOrdinalIncr = (yyvsp[(2) - (3)].Number);
@@ -1823,10 +1865,10 @@ yyreduce:
 	;}
     break;
 
-  case 38:
+  case 43:
 
     {
-	    if ((yyvsp[(2) - (3)].Number) != HOUR( 7)) YYABORT;
+	    if ((yyvsp[(2) - (3)].Number) != HOUR( 7)) YYABORT; /* T */
 	    yyYear = (yyvsp[(1) - (3)].Number) / 10000;
 	    yyMonth = ((yyvsp[(1) - (3)].Number) % 10000)/100;
 	    yyDay = (yyvsp[(1) - (3)].Number) % 100;
@@ -1836,20 +1878,7 @@ yyreduce:
 	;}
     break;
 
-  case 39:
-
-    {
-	    if ((yyvsp[(2) - (7)].Number) != HOUR( 7)) YYABORT;
-	    yyYear = (yyvsp[(1) - (7)].Number) / 10000;
-	    yyMonth = ((yyvsp[(1) - (7)].Number) % 10000)/100;
-	    yyDay = (yyvsp[(1) - (7)].Number) % 100;
-	    yyHour = (yyvsp[(3) - (7)].Number);
-	    yyMinutes = (yyvsp[(5) - (7)].Number);
-	    yySeconds = (yyvsp[(7) - (7)].Number);
-	;}
-    break;
-
-  case 40:
+  case 44:
 
     {
 	    yyYear = (yyvsp[(1) - (2)].Number) / 10000;
@@ -1861,7 +1890,44 @@ yyreduce:
 	;}
     break;
 
-  case 41:
+  case 45:
+
+    {
+	    yyYear = (yyvsp[(1) - (7)].Number) / 10000;
+	    yyMonth = ((yyvsp[(1) - (7)].Number) % 10000)/100;
+	    yyDay = (yyvsp[(1) - (7)].Number) % 100;
+	    yyHour = (yyvsp[(3) - (7)].Number);
+	    yyMinutes = (yyvsp[(5) - (7)].Number);
+	    yySeconds = (yyvsp[(7) - (7)].Number);
+	;}
+    break;
+
+  case 46:
+
+    {
+	    if ((yyvsp[(2) - (7)].Number) != HOUR( 7)) YYABORT; /* T */
+	    yyYear = (yyvsp[(1) - (7)].Number) / 10000;
+	    yyMonth = ((yyvsp[(1) - (7)].Number) % 10000)/100;
+	    yyDay = (yyvsp[(1) - (7)].Number) % 100;
+	    yyHour = (yyvsp[(3) - (7)].Number);
+	    yyMinutes = (yyvsp[(5) - (7)].Number);
+	    yySeconds = (yyvsp[(7) - (7)].Number);
+	;}
+    break;
+
+  case 47:
+
+    {
+	    yyYear = (yyvsp[(1) - (3)].Number) / 10000;
+	    yyMonth = ((yyvsp[(1) - (3)].Number) % 10000)/100;
+	    yyDay = (yyvsp[(1) - (3)].Number) % 100;
+	    yyHour = (yyvsp[(3) - (3)].Number) / 10000;
+	    yyMinutes = ((yyvsp[(3) - (3)].Number) % 10000)/100;
+	    yySeconds = (yyvsp[(3) - (3)].Number) % 100;
+	;}
+    break;
+
+  case 48:
 
     {
 	    /*
@@ -1877,7 +1943,7 @@ yyreduce:
 	;}
     break;
 
-  case 42:
+  case 49:
 
     {
 	    yyRelSeconds *= -1;
@@ -1886,56 +1952,63 @@ yyreduce:
 	;}
     break;
 
-  case 44:
+  case 51:
+
+    {
+	    *yyRelPointer += (yyvsp[(1) - (4)].Number) * (yyvsp[(3) - (4)].Number) * (yyvsp[(4) - (4)].Number);
+	;}
+    break;
+
+  case 52:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (3)].Number) * (yyvsp[(2) - (3)].Number) * (yyvsp[(3) - (3)].Number);
 	;}
     break;
 
-  case 45:
+  case 53:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (2)].Number) * (yyvsp[(2) - (2)].Number);
 	;}
     break;
 
-  case 46:
+  case 54:
 
     {
 	    *yyRelPointer += (yyvsp[(2) - (2)].Number);
 	;}
     break;
 
-  case 47:
+  case 55:
 
     {
 	    *yyRelPointer += (yyvsp[(2) - (3)].Number) * (yyvsp[(3) - (3)].Number);
 	;}
     break;
 
-  case 48:
+  case 56:
 
     {
 	    *yyRelPointer += (yyvsp[(1) - (1)].Number);
 	;}
     break;
 
-  case 49:
+  case 57:
 
     {
 	    (yyval.Number) = -1;
 	;}
     break;
 
-  case 50:
+  case 58:
 
     {
 	    (yyval.Number) =  1;
 	;}
     break;
 
-  case 51:
+  case 59:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
@@ -1943,7 +2016,7 @@ yyreduce:
 	;}
     break;
 
-  case 52:
+  case 60:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
@@ -1951,7 +2024,7 @@ yyreduce:
 	;}
     break;
 
-  case 53:
+  case 61:
 
     {
 	    (yyval.Number) = (yyvsp[(1) - (1)].Number);
@@ -1959,7 +2032,21 @@ yyreduce:
 	;}
     break;
 
-  case 54:
+  case 62:
+
+    {
+	    (yyval.Number) = (yyvsp[(1) - (1)].Number)
+	;}
+    break;
+
+  case 63:
+
+    {
+	    (yyval.Number) = (yyvsp[(1) - (1)].Number)
+	;}
+    break;
+
+  case 64:
 
     {
 	    if (yyHaveTime && yyHaveDate && !yyHaveRel) {
@@ -1979,14 +2066,14 @@ yyreduce:
 	;}
     break;
 
-  case 55:
+  case 65:
 
     {
 	    (yyval.Meridian) = MER24;
 	;}
     break;
 
-  case 56:
+  case 66:
 
     {
 	    (yyval.Meridian) = (yyvsp[(1) - (1)].Meridian);
@@ -2414,6 +2501,18 @@ static const TABLE MilitaryTable[] = {
     { NULL, 0, 0 }
 };
 
+static inline const char *
+bypassSpaces(
+    register const char *s)
+{
+    if (isspace(UCHAR(*s))) {
+	do {
+	    s++;
+	} while (isspace(UCHAR(*s)));
+    }
+    return s;
+}
+
 /*
  * Dump error messages in the bit bucket.
  */
@@ -2487,11 +2586,11 @@ LookupWord(
 
     Tcl_UtfToLower(buff);
 
-    if (strcmp(buff, "am") == 0 || strcmp(buff, "a.m.") == 0) {
+    if (*buff == 'a' && (strcmp(buff, "am") == 0 || strcmp(buff, "a.m.") == 0)) {
 	yylvalPtr->Meridian = MERam;
 	return tMERIDIAN;
     }
-    if (strcmp(buff, "pm") == 0 || strcmp(buff, "p.m.") == 0) {
+    if (*buff == 'p' && (strcmp(buff, "pm") == 0 || strcmp(buff, "p.m.") == 0)) {
 	yylvalPtr->Meridian = MERpm;
 	return tMERIDIAN;
     }
@@ -2608,29 +2707,38 @@ TclDatelex(
 
     location->first_column = yyInput - info->dateStart;
     for ( ; ; ) {
-	while (isspace(UCHAR(*yyInput))) {
-	    yyInput++;
+
+	if (isspace(UCHAR(*yyInput))) {
+	    yyInput = bypassSpaces(yyInput);
+	    /* ignore space at end of text and before some words */
+	    c = *yyInput;
+	    if (c != '\0' && !isalpha(UCHAR(c))) {
+		return SP;
+	    }
 	}
 
 	if (isdigit(UCHAR(c = *yyInput))) { /* INTL: digit */
+	    
 	    /*
 	     * Convert the string into a number; count the number of digits.
 	     */
+	    register int num = c - '0';
+	    p = (char *)yyInput;
+	    while (isdigit(UCHAR(c = *(++p)))) {
+		num *= 10;
+		num += c - '0';
+	    };
+	    yylvalPtr->Number = num;
+	    yyDigitCount = p - yyInput;
+	    yyInput = p;
 
-	    Count = 0;
-	    for (yylvalPtr->Number = 0;
-		    isdigit(UCHAR(c = *yyInput++)); ) {	  /* INTL: digit */
-		yylvalPtr->Number = 10 * yylvalPtr->Number + c - '0';
-		Count++;
-	    }
-	    yyInput--;
-	    yyDigitCount = Count;
-
+	    /* ignore spaces after digits (optional) */
+	    yyInput = bypassSpaces(yyInput);
 	    /*
 	     * A number with 6 or more digits is considered an ISO 8601 base.
 	     */
 
-	    if (Count >= 6) {
+	    if (yyDigitCount >= 6) {
 		location->last_column = yyInput - info->dateStart - 1;
 		return tISOBASE;
 	    } else {
@@ -2639,6 +2747,7 @@ TclDatelex(
 	    }
 	}
 	if (!(c & 0x80) && isalpha(UCHAR(c))) {		  /* INTL: ISO only. */
+	    int ret;
 	    for (p = buff; isalpha(UCHAR(c = *yyInput++)) /* INTL: ISO only. */
 		     || c == '.'; ) {
 		if (p < &buff[sizeof buff - 1]) {
@@ -2648,7 +2757,30 @@ TclDatelex(
 	    *p = '\0';
 	    yyInput--;
 	    location->last_column = yyInput - info->dateStart - 1;
-	    return LookupWord(yylvalPtr, buff);
+	    ret = LookupWord(yylvalPtr, buff);
+	    /* 
+	     * lookahead for +/- digit, to differentiate between "GMT+1000 day" and "GMT +1000 day",
+	     * bypass spaces after token (but ignore by TZ+OFFS), because should 
+	     * recognize next SP token, if TZ only.
+	     */
+	    if (ret == tZONE || ret == tDAYZONE) {
+		c = *yyInput;
+		if ((c == '+' || c == '-') && isdigit(UCHAR(*(yyInput+1)))) {
+		    if ( !isdigit(UCHAR(*(yyInput+2)))
+		      || !isdigit(UCHAR(*(yyInput+3)))) {
+			/* GMT+1, GMT-10, etc. */
+			return tZONEwO2;
+		    }
+		    if ( isdigit(UCHAR(*(yyInput+4)))
+		      && !isdigit(UCHAR(*(yyInput+5)))) {
+			/* GMT+1000, etc. */
+			return tZONEwO4;
+		    }
+		}
+	    }
+	    yyInput = bypassSpaces(yyInput);
+	    return ret;
+
 	}
 	if (c != '(') {
 	    location->last_column = yyInput - info->dateStart;
@@ -2676,6 +2808,11 @@ TclClockFreeScan(
 {
     int status;
 
+  #if YYDEBUG
+    /* enable debugging if compiled with YYDEBUG */
+    yydebug = 1;
+  #endif
+
     /*
      * yyInput = stringToParse;
      *
@@ -2689,6 +2826,11 @@ TclClockFreeScan(
     Tcl_IncrRefCount(info->messages);
 
     info->dateStart = yyInput;
+
+    /* ignore spaces at begin */
+    yyInput = bypassSpaces(yyInput);
+
+    /* parse */
     status = yyparse(info);
     if (status == 1) {
 	Tcl_SetObjResult(interp, info->messages);

--- a/generic/tclGetDate.y
+++ b/generic/tclGetDate.y
@@ -195,28 +195,11 @@ time	: tUNUMBER tMERIDIAN {
 	    yySeconds = 0;
 	    yyMeridian = $4;
 	}
-	| tUNUMBER ':' tUNUMBER '-' tUNUMBER {
-	    yyHour = $1;
-	    yyMinutes = $3;
-	    yyMeridian = MER24;
-	    yyDSTmode = DSToff;
-	    yyTimezone = ($5 % 100 + ($5 / 100) * 60);
-	    ++yyHaveZone;
-	}
 	| tUNUMBER ':' tUNUMBER ':' tUNUMBER o_merid {
 	    yyHour = $1;
 	    yyMinutes = $3;
 	    yySeconds = $5;
 	    yyMeridian = $6;
-	}
-	| tUNUMBER ':' tUNUMBER ':' tUNUMBER '-' tUNUMBER {
-	    yyHour = $1;
-	    yyMinutes = $3;
-	    yySeconds = $5;
-	    yyMeridian = MER24;
-	    yyDSTmode = DSToff;
-	    yyTimezone = ($7 % 100 + ($7 / 100) * 60);
-	    ++yyHaveZone;
 	}
 	;
 
@@ -231,6 +214,10 @@ zone	: tZONE tDST {
 	| tDAYZONE {
 	    yyTimezone = $1;
 	    yyDSTmode = DSTon;
+	}
+	| sign tUNUMBER {
+	    yyTimezone = -$1*($2 % 100 + ($2 / 100) * 60);
+	    yyDSTmode = DSToff;
 	}
 	;
 
@@ -659,7 +646,7 @@ TclDateerror(
     infoPtr->separatrix = "\n";
 }
 
-MODULE_SCOPE int
+int
 ToSeconds(
     int Hours,
     int Minutes,

--- a/generic/tclGetDate.y
+++ b/generic/tclGetDate.y
@@ -219,6 +219,10 @@ zone	: tZONE tDST {
 	    yyTimezone = -$1*($2 % 100 + ($2 / 100) * 60);
 	    yyDSTmode = DSToff;
 	}
+	| tZONE sign tUNUMBER {
+	    yyTimezone = $1 - $2*($3 % 100 + ($3 / 100) * 60);
+	    yyDSTmode = DSToff;
+	}
 	;
 
 day	: tDAY {

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -35972,6 +35972,28 @@ test clock-34.20.10 {clock scan tests (merid and TZ)} {
     set time [clock scan "10:59 pm +0100" -base 2000000]
     clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
 } {Jan 24,1970 21:59:00 GMT}
+test clock-34.20.11 {clock scan tests (complex TZ)} {
+    list [clock scan "GMT+1000" -base 100000000 -gmt 1] \
+	 [clock scan "+1000" -base 100000000 -gmt 1]
+} {99964000 99964000}
+test clock-34.20.12 {clock scan tests (complex TZ)} {
+    list [clock scan "GMT-1000" -base 100000000 -gmt 1] \
+	 [clock scan "-1000" -base 100000000 -gmt 1]
+} {100036000 100036000}
+test clock-34.20.13 {clock scan tests (complex TZ)} {
+    list [clock scan "GMT-0000" -base 100000000 -gmt 1] \
+	 [clock scan "GMT+0000" -base 100000000 -gmt 1] \
+	 [clock scan "GMT" -base 100000000 -gmt 1]
+} [lrepeat 3 100000000]
+test clock-34.20.14 {clock scan tests (complex TZ)} {
+    list [clock scan "CET+1000" -base 100000000 -gmt 1] \
+	 [clock scan "CET-1000" -base 100000000 -gmt 1]
+} {99960400 100032400}
+test clock-34.20.15 {clock scan tests (complex TZ)} {
+    list [clock scan "CET-0000" -base 100000000 -gmt 1] \
+	 [clock scan "CET+0000" -base 100000000 -gmt 1] \
+	 [clock scan "CET" -base 100000000 -gmt 1]
+} [lrepeat 3 99996400]
 
 # CLOCK SCAN REAL TESTS
 # We use 5am PST, 31-12-1999 as the base for these scans because irrespective

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -35974,12 +35974,14 @@ test clock-34.20.10 {clock scan tests (merid and TZ)} {
 } {Jan 24,1970 21:59:00 GMT}
 test clock-34.20.11 {clock scan tests (complex TZ)} {
     list [clock scan "GMT+1000" -base 100000000 -gmt 1] \
+	 [clock scan "GMT+10" -base 100000000 -gmt 1] \
 	 [clock scan "+1000" -base 100000000 -gmt 1]
-} {99964000 99964000}
+} [lrepeat 3 99964000]
 test clock-34.20.12 {clock scan tests (complex TZ)} {
     list [clock scan "GMT-1000" -base 100000000 -gmt 1] \
+	 [clock scan "GMT-10" -base 100000000 -gmt 1] \
 	 [clock scan "-1000" -base 100000000 -gmt 1]
-} {100036000 100036000}
+} [lrepeat 3 100036000]
 test clock-34.20.13 {clock scan tests (complex TZ)} {
     list [clock scan "GMT-0000" -base 100000000 -gmt 1] \
 	 [clock scan "GMT+0000" -base 100000000 -gmt 1] \
@@ -35994,6 +35996,36 @@ test clock-34.20.15 {clock scan tests (complex TZ)} {
 	 [clock scan "CET+0000" -base 100000000 -gmt 1] \
 	 [clock scan "CET" -base 100000000 -gmt 1]
 } [lrepeat 3 99996400]
+test clock-34.20.16 {clock scan tests (complex TZ)} {
+    list [clock format [clock scan "00:00 GMT+1000" -base 100000000 -gmt 1] -gmt 1] \
+	 [clock format [clock scan "00:00 GMT+10" -base 100000000 -gmt 1] -gmt 1] \
+	 [clock format [clock scan "00:00 +1000" -base 100000000 -gmt 1] -gmt 1] \
+	 [clock format [clock scan "00:00" -base 100000000 -timezone +1000] -gmt 1]
+} [lrepeat 4 "Fri Mar 02 14:00:00 GMT 1973"]
+test clock-34.20.17 {clock scan tests (complex TZ)} {
+    list [clock format [clock scan "00:00 GMT+0100" -base 100000000 -gmt 1] -gmt 1] \
+	 [clock format [clock scan "00:00 GMT+01" -base 100000000 -gmt 1] -gmt 1] \
+	 [clock format [clock scan "00:00 GMT+1" -base 100000000 -gmt 1] -gmt 1] \
+	 [clock format [clock scan "00:00" -base 100000000 -timezone +0100] -gmt 1]
+} [lrepeat 4 "Fri Mar 02 23:00:00 GMT 1973"]
+test clock-34.20.18 {clock scan tests (no TZ)} {
+    list [clock scan "1000days" -base 100000000 -gmt 1] \
+	 [clock scan "1000 days" -base 100000000 -gmt 1] \
+	 [clock scan "+1000days" -base 100000000 -gmt 1] \
+	 [clock scan "+1000 days" -base 100000000 -gmt 1] \
+	 [clock scan "GMT +1000 days" -base 100000000 -gmt 1] \
+	 [clock scan "00:00 GMT +1000 days" -base 100000000 -gmt 1]
+} [lrepeat 6 186364800]
+test clock-34.20.19 {clock scan tests (no TZ)} {
+    list [clock scan "-1000days" -base 100000000 -gmt 1] \
+	 [clock scan "-1000 days" -base 100000000 -gmt 1] \
+	 [clock scan "GMT -1000days" -base 100000000 -gmt 1] \
+	 [clock scan "00:00 GMT -1000 days" -base 100000000 -gmt 1] \
+} [lrepeat 4 13564800]
+test clock-34.20.20 {clock scan tests (TZ, TZ + 1day)} {
+    clock scan "00:00 GMT+1000 day" -base 100000000 -gmt 1
+} 100015200
+
 
 # CLOCK SCAN REAL TESTS
 # We use 5am PST, 31-12-1999 as the base for these scans because irrespective

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -35932,6 +35932,46 @@ test clock-34.18 {clock scan, ISO 8601 point in time format} {
     set time [clock scan "19921023T000000"]
     clock format $time -format {%b %d, %Y %H:%M:%S}
 } "Oct 23, 1992 00:00:00"
+test clock-34.20.1 {clock scan tests (-TZ)} {
+    set time [clock scan "31 Jan 14 23:59:59 -0100"]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Feb 01,2014 00:59:59 GMT}
+test clock-34.20.2 {clock scan tests (+TZ)} {
+    set time [clock scan "31 Jan 14 23:59:59 +0100"]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 31,2014 22:59:59 GMT}
+test clock-34.20.3 {clock scan tests (-TZ)} {
+    set time [clock scan "23:59:59 -0100" -base 0]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 02,1970 00:59:59 GMT}
+test clock-34.20.4 {clock scan tests (+TZ)} {
+    set time [clock scan "23:59:59 +0100" -base 0]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 01,1970 22:59:59 GMT}
+test clock-34.20.5 {clock scan tests (TZ)} {
+    set time [clock scan "Mon, 30 Jun 2014 23:59:59 CEST"]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jun 30,2014 21:59:59 GMT}
+test clock-34.20.6 {clock scan tests (TZ)} {
+    set time [clock scan "Fri, 31 Jan 2014 23:59:59 CET"]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 31,2014 22:59:59 GMT}
+test clock-34.20.7 {clock scan tests (relspec, day unit not TZ)} {
+    set time [clock scan "23:59:59 +15 day" -base 2000000]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Feb 08,1970 22:59:59 GMT}
+test clock-34.20.8 {clock scan tests (relspec, day unit not TZ)} {
+    set time [clock scan "23:59:59 -15 day" -base 2000000]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 09,1970 22:59:59 GMT}
+test clock-34.20.9 {clock scan tests (merid and TZ)} {
+    set time [clock scan "10:59 pm CET" -base 2000000]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 24,1970 21:59:00 GMT}
+test clock-34.20.10 {clock scan tests (merid and TZ)} {
+    set time [clock scan "10:59 pm +0100" -base 2000000]
+    clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
+} {Jan 24,1970 21:59:00 GMT}
 
 # CLOCK SCAN REAL TESTS
 # We use 5am PST, 31-12-1999 as the base for these scans because irrespective

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -35957,13 +35957,13 @@ test clock-34.20.6 {clock scan tests (TZ)} {
     clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
 } {Jan 31,2014 22:59:59 GMT}
 test clock-34.20.7 {clock scan tests (relspec, day unit not TZ)} {
-    set time [clock scan "23:59:59 +15 day" -base 2000000]
+    set time [clock scan "23:59:59 +15 day" -base 2000000 -gmt true]
     clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
-} {Feb 08,1970 22:59:59 GMT}
+} {Feb 08,1970 23:59:59 GMT}
 test clock-34.20.8 {clock scan tests (relspec, day unit not TZ)} {
-    set time [clock scan "23:59:59 -15 day" -base 2000000]
+    set time [clock scan "23:59:59 -15 day" -base 2000000 -gmt true]
     clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true
-} {Jan 09,1970 22:59:59 GMT}
+} {Jan 09,1970 23:59:59 GMT}
 test clock-34.20.9 {clock scan tests (merid and TZ)} {
     set time [clock scan "10:59 pm CET" -base 2000000]
     clock format $time -format {%b %d,%Y %H:%M:%S %Z} -gmt true


### PR DESCRIPTION
* FreeScan: repair scanning date/time with TZ using '+', ex.: "31 Jan 14 23:59:59 +0100", additionally another TZ formats can be used now (token [zone] used instead of sequence '-' tNUMBER); test cases extended.
  Closes http://core.tcl.tk/tcl/tktview?name=5019748c73
  Cherry picked from fossil branch "sebres_clock_tz_fix", check-in [5f72c863f17145b4]

* FreeScan: rewritten lexer rules and some tokens for better space recognition; 
  fewer conflicts (shift/reduce, reduce/reduce);
  differentiate between TZ like "GMT+1" and relative offsets "GMT +1 day", etc.;
  test-cases extended for new cases.

