### PR TITLE
Fix compatibility regressions on white-spaces

### DIFF
--- a/generic/tclClockFmt.c
+++ b/generic/tclClockFmt.c
@@ -2310,7 +2310,10 @@ ClockScan(
     while (tok->map != NULL) {
 	if (!(opts->flags & CLF_STRICT) && (tok->map->type == CTOKT_SPACE)) {
 	    tok++;
-	    if (tok->map == NULL) break;
+	    if (tok->map == NULL) {
+		/* no tokens anymore - trailing spaces are mandatory */
+		goto not_match;
+	    }
 	}
 	if (!(tok->map->flags & CLF_OPTIONAL)) {
 	    goto not_match;

--- a/generic/tclClockFmt.c
+++ b/generic/tclClockFmt.c
@@ -1862,11 +1862,10 @@ static const char *ScnOTokenMapAliasIndex[2] = {
     "dHHHu"
 };
 
-static const char *ScnSpecTokenMapIndex =
-    " ";
-static ClockScanTokenMap ScnSpecTokenMap[] = {
-    {CTOKT_SPACE,  0, 0, 1, 1, 0,
-	NULL},
+/* Token map reserved for CTOKT_SPACE */
+static ClockScanTokenMap ScnSpaceTokenMap = {
+    CTOKT_SPACE,  0, 0, 1, 1, 0,
+	NULL,
 };
 
 static ClockScanTokenMap ScnWordTokenMap = {
@@ -2035,21 +2034,20 @@ ClockGetOrParseScanFormat(
 		continue;
 	    }
 	    break;
-	    case ' ':
-		cp = strchr(ScnSpecTokenMapIndex, *p);
-		if (!cp || *cp == '\0') {
-		    p--;
-		    goto word_tok;
+	    default:
+	    if ( *p == ' ' || isspace(UCHAR(*p)) ) {
+		tok->map = &ScnSpaceTokenMap;
+		tok->tokWord.start = p++;
+		while (p < e && isspace(UCHAR(*p))) {
+		    p++;
 		}
-		tok->map = &ScnSpecTokenMap[cp - ScnSpecTokenMapIndex];
+		tok->tokWord.end = p;
 		/* increase space count used in format */
 		fss->scnSpaceCount++;
 		/* next token */
 		AllocTokenInChain(tok, scnTok, fss->scnTokC); tokCnt++;
-		p++;
 		continue;
-	    break;
-	    default:
+	    }
 word_tok:
 	    if (1) {
 		ClockScanToken	 *wordTok = tok;

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -50,13 +50,14 @@ proc ::tcltest::__SortFiles {lst} {
 }
 
 set TESTDIR [file normalize [file dirname [info script]]]
-# switch to temp directory:
-if {[catch {
-  cd $::env(TEMP)
-}]} {
-  cd /tmp/
+if {![::tcl::pkgconfig get debug]} { # allow to load lib from current directory in debug:
+  # switch to temp directory:
+  if {[catch {
+    cd $::env(TEMP)
+  }]} {
+    cd /tmp/
+  }
 }
-
 set GLOB_OPTIONS {
   puts [outputChannel] "  Load library ..."
   # load library:

--- a/tests/clock.test
+++ b/tests/clock.test
@@ -36511,12 +36511,53 @@ test clock-44.1 {regression test - time zone name containing hyphen } \
 	}
     } \
     -result {12:34:56-0500}
-
-test clock-45.1 {regression test - time zone containing only two digits} \
+test clock-44.2 {regression test - time zone containing only two digits} \
     -body {
 	clock scan 1985-04-12T10:15:30+04 -format %Y-%m-%dT%H:%M:%S%Z
     } \
     -result 482134530
+
+test clock-45.1 {compat: scan regression on spaces (multiple spaces in format)} \
+    -body {
+	list \
+	    [clock scan "11/08/2018  0612"      -format "%m/%d/%Y  %H%M" -gmt 1] \
+	    [clock scan "11/08/2018   0612"     -format "%m/%d/%Y   %H%M" -gmt 1] \
+	    [clock scan "11/08/2018    0612"    -format "%m/%d/%Y   %H%M" -gmt 1] \
+	    [clock scan "  11/08/2018  0612"    -format "  %m/%d/%Y  %H%M" -gmt 1] \
+	    [clock scan "  11/08/2018   0612"   -format "  %m/%d/%Y   %H%M" -gmt 1] \
+	    [clock scan "  11/08/2018    0612"  -format "  %m/%d/%Y   %H%M" -gmt 1] \
+	    [clock scan "11/08/2018  0612  "    -format "%m/%d/%Y  %H%M  " -gmt 1] \
+	    [clock scan "11/08/2018   0612  "   -format "%m/%d/%Y   %H%M  " -gmt 1] \
+	    [clock scan "11/08/2018    0612  "  -format "%m/%d/%Y   %H%M  " -gmt 1]
+    } -result [lrepeat 9 1541657520]
+
+test clock-45.2 {compat: scan regression on spaces (multiple leading/trailing spaces in input)} \
+    -body {
+	set sp [string repeat " " 20]
+	list \
+	    [clock scan "NOV   7${sp}"             -format "%b %d" -base 0 -gmt 1 -locale en] \
+	    [clock scan "${sp}NOV   7"             -format "%b %d" -base 0 -gmt 1 -locale en] \
+	    [clock scan "${sp}NOV   7${sp}"        -format "%b %d" -base 0 -gmt 1 -locale en] \
+	    [clock scan "1970   NOV   7${sp}"      -format "%Y %b %d" -gmt 1 -locale en] \
+	    [clock scan "${sp}1970   NOV   7"      -format "%Y %b %d" -gmt 1 -locale en] \
+	    [clock scan "${sp}1970   NOV   7${sp}" -format "%Y %b %d" -gmt 1 -locale en]
+    } -result [lrepeat 6 26784000]
+test clock-45.3 {compat: scan regression on spaces (shortest match)} \
+    -body {
+	list \
+	    [clock scan "11 1 120" -format "%y%m%d %H%M%S" -gmt 1] \
+	    [clock scan "11 1 120 " -format "%y%m%d %H%M%S" -gmt 1] \
+	    [clock scan " 11 1 120" -format "%y%m%d %H%M%S" -gmt 1] \
+	    [clock scan "11 1 120        " -format "%y%m%d %H%M%S " -gmt 1] \
+	    [clock scan "         11 1 120" -format " %y%m%d %H%M%S" -gmt 1]
+    } -result [lrepeat 5 978310920]
+test clock-45.4 {compat: scan regression on spaces (mandatory leading/trailing spaces in format)} \
+    -body {
+	list \
+	    [catch {clock scan "11 1 120" -format "%y%m%d %H%M%S " -gmt 1} ret] $ret \
+	    [catch {clock scan "11 1 120" -format " %y%m%d %H%M%S" -gmt 1} ret] $ret \
+	    [catch {clock scan "11 1 120" -format " %y%m%d %H%M%S " -gmt 1} ret] $ret
+    } -result [lrepeat 3 1 "input string does not match supplied format"]
 
 test clock-46.1 {regression test - month zero} -constraints valid_off \
     -body {


### PR DESCRIPTION
* clock scan: consider multiple spaces between tokens (closes #13): combine multiple white-spaces as single token in format.
* clock scan: consider extra trailing spaces at end of input (closes #14), only the first space at end is interesting in non-strict mode (should match SPACE token if present in scan-format)
* test-cases: clock-45.* - new compatibility tests checking several scan regression on spaces
* clock scan: compatibility - scan regression on spaces, mandatory trailing spaces in format, see test "clock-45.4"