### PR TITLE
Simplifying info structure, yacc rules and flags

### DIFF
--- a/generic/tclClock.c
+++ b/generic/tclClock.c
@@ -3819,15 +3819,13 @@ ClockValidDate(
 	}
     }
     /* and month (used later in hath) */
-    if (info->flags & (CLF_MONTH|CLF_DATE)) {
-    	info->flags |= CLF_MONTH;
+    if (info->flags & CLF_MONTH) {
 	if ( yyMonth < 1 || yyMonth > 12 ) {
 	    errMsg = "invalid month"; errCode = "month"; goto error;
 	}
     }
     /* day of month */
     if (info->flags & (CLF_DAYOFMONTH|CLF_DAYOFWEEK)) {
-    	info->flags |= CLF_DAYOFMONTH;
 	if ( yyDay < 1 || yyDay > 31 ) {
 	    errMsg = "invalid day"; errCode = "day"; goto error;
 	}

--- a/generic/tclDate.c
+++ b/generic/tclDate.c
@@ -123,6 +123,13 @@
 #define SECSPERDAY	(24L * 60L * 60L)
 #define IsLeapYear(x)	((x % 4 == 0) && (x % 100 != 0 || x % 400 == 0))
 
+#define yyIncrFlags(f)				\
+    do {					\
+	info->errFlags |= (info->flags & (f));	\
+	if (info->errFlags) { YYABORT; }	\
+	info->flags |= (f);			\
+    } while (0);
+
 /*
  * An entry in the lexical lookup table.
  */
@@ -551,13 +558,13 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   160,   160,   161,   162,   165,   168,   171,   174,   177,
-     180,   183,   187,   192,   195,   201,   207,   215,   219,   223,
-     227,   231,   235,   241,   242,   245,   250,   255,   260,   265,
-     270,   277,   281,   286,   291,   296,   301,   305,   310,   314,
-     319,   326,   330,   336,   345,   353,   361,   370,   380,   394,
-     399,   402,   405,   408,   411,   414,   417,   422,   425,   430,
-     434,   438,   444,   447,   452,   470,   473
+       0,   167,   167,   168,   169,   172,   175,   178,   181,   184,
+     187,   190,   193,   196,   199,   205,   211,   219,   223,   227,
+     231,   235,   239,   245,   246,   249,   253,   257,   261,   265,
+     269,   275,   279,   284,   289,   294,   299,   303,   308,   312,
+     317,   324,   328,   334,   343,   351,   359,   368,   378,   392,
+     397,   400,   403,   406,   409,   412,   415,   420,   423,   428,
+     432,   436,   442,   445,   450,   468,   471
 };
 #endif
 
@@ -1501,7 +1508,7 @@ yyreduce:
         case 5:
 
     {
-	    yyHaveTime++;
+	    yyIncrFlags(CLF_TIME);
 	}
 
     break;
@@ -1509,7 +1516,7 @@ yyreduce:
   case 6:
 
     {
-	    yyHaveZone++;
+	    yyIncrFlags(CLF_ZONE);
 	}
 
     break;
@@ -1517,7 +1524,7 @@ yyreduce:
   case 7:
 
     {
-	    yyHaveDate++;
+	    yyIncrFlags(CLF_HAVEDATE);
 	}
 
     break;
@@ -1525,7 +1532,7 @@ yyreduce:
   case 8:
 
     {
-	    yyHaveOrdinalMonth++;
+	    yyIncrFlags(CLF_ORDINALMONTH);
 	}
 
     break;
@@ -1533,7 +1540,7 @@ yyreduce:
   case 9:
 
     {
-	    yyHaveDay++;
+	    yyIncrFlags(CLF_DAYOFWEEK);
 	}
 
     break;
@@ -1541,7 +1548,7 @@ yyreduce:
   case 10:
 
     {
-	    yyHaveRel++;
+	    yyIncrFlags(CLF_RELCONV);
 	}
 
     break;
@@ -1549,8 +1556,7 @@ yyreduce:
   case 11:
 
     {
-	    yyHaveTime++;
-	    yyHaveDate++;
+	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE);
 	}
 
     break;
@@ -1558,9 +1564,7 @@ yyreduce:
   case 12:
 
     {
-	    yyHaveTime++;
-	    yyHaveDate++;
-	    yyHaveRel++;
+	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE|CLF_RELCONV);
 	}
 
     break;
@@ -1657,7 +1661,6 @@ yyreduce:
     {
 	    yyDayOrdinal = 1;
 	    yyDayOfWeek = (yyvsp[0].Number);
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 
     break;
@@ -1667,7 +1670,6 @@ yyreduce:
     {
 	    yyDayOrdinal = 1;
 	    yyDayOfWeek = (yyvsp[-1].Number);
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 
     break;
@@ -1677,7 +1679,6 @@ yyreduce:
     {
 	    yyDayOrdinal = (yyvsp[-1].Number);
 	    yyDayOfWeek = (yyvsp[0].Number);
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 
     break;
@@ -1687,7 +1688,6 @@ yyreduce:
     {
 	    yyDayOrdinal = (yyvsp[-3].Number) * (yyvsp[-1].Number);
 	    yyDayOfWeek = (yyvsp[0].Number);
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 
     break;
@@ -1697,7 +1697,6 @@ yyreduce:
     {
 	    yyDayOrdinal = (yyvsp[-2].Number) * (yyvsp[-1].Number);
 	    yyDayOfWeek = (yyvsp[0].Number);
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 
     break;
@@ -1707,7 +1706,6 @@ yyreduce:
     {
 	    yyDayOrdinal = 2;
 	    yyDayOfWeek = (yyvsp[0].Number);
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 
     break;
@@ -2031,10 +2029,10 @@ yyreduce:
   case 64:
 
     {
-	    if (yyHaveTime && yyHaveDate && !yyHaveRel) {
+	    if ((info->flags & (CLF_TIME|CLF_HAVEDATE|CLF_RELCONV)) == (CLF_TIME|CLF_HAVEDATE)) {
 		yyYear = (yyvsp[0].Number);
 	    } else {
-		yyHaveTime++;
+		yyIncrFlags(CLF_TIME);
 		if (yyDigitCount <= 2) {
 		    yyHour = (yyvsp[0].Number);
 		    yyMinutes = 0;
@@ -2857,31 +2855,31 @@ TclClockFreeScan(
     }
     Tcl_DecrRefCount(info->messages);
 
-    if (yyHaveDate > 1) {
+    if (info->errFlags & CLF_HAVEDATE) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one date in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveTime > 1) {
+    if (info->errFlags & CLF_TIME) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one time of day in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveZone > 1) {
+    if (info->errFlags & CLF_ZONE) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one time zone in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveDay > 1) {
+    if (info->errFlags & CLF_DAYOFWEEK) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one weekday in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveOrdinalMonth > 1) {
+    if (info->errFlags & CLF_ORDINALMONTH) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one ordinal month in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);

--- a/generic/tclDate.c
+++ b/generic/tclDate.c
@@ -559,12 +559,12 @@ static const yytype_uint8 yytranslate[] =
 static const yytype_uint16 yyrline[] =
 {
        0,   167,   167,   168,   169,   172,   175,   178,   181,   184,
-     187,   190,   193,   196,   199,   205,   211,   219,   223,   227,
-     231,   235,   239,   245,   246,   249,   253,   257,   261,   265,
-     269,   275,   279,   284,   289,   294,   299,   303,   308,   312,
-     317,   324,   328,   334,   343,   351,   359,   368,   378,   392,
-     397,   400,   403,   406,   409,   412,   415,   420,   423,   428,
-     432,   436,   442,   445,   450,   468,   471
+     187,   190,   193,   197,   200,   206,   212,   220,   224,   228,
+     232,   236,   240,   246,   247,   250,   254,   258,   262,   266,
+     270,   276,   280,   285,   290,   295,   300,   304,   309,   313,
+     318,   325,   329,   335,   344,   352,   360,   369,   379,   393,
+     398,   401,   404,   407,   410,   413,   416,   421,   424,   429,
+     433,   437,   443,   446,   451,   469,   472
 };
 #endif
 
@@ -1548,7 +1548,7 @@ yyreduce:
   case 10:
 
     {
-	    yyIncrFlags(CLF_RELCONV);
+	    info->flags |= CLF_RELCONV;
 	}
 
     break;
@@ -1564,7 +1564,8 @@ yyreduce:
   case 12:
 
     {
-	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE|CLF_RELCONV);
+	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE);
+	    info->flags |= CLF_RELCONV;
 	}
 
     break;
@@ -2526,6 +2527,9 @@ TclDateerror(
     const char *s)
 {
     Tcl_Obj* t;
+    if (!infoPtr->messages) {
+	infoPtr->messages = Tcl_NewObj();
+    }
     Tcl_AppendToObj(infoPtr->messages, infoPtr->separatrix, -1);
     Tcl_AppendToObj(infoPtr->messages, s, -1);
     Tcl_AppendToObj(infoPtr->messages, " (characters ", -1);
@@ -2823,9 +2827,7 @@ TclClockFreeScan(
 
     yyDSTmode = DSTmaybe;
 
-    info->messages = Tcl_NewObj();
     info->separatrix = "";
-    Tcl_IncrRefCount(info->messages);
 
     info->dateStart = yyInput;
 
@@ -2835,58 +2837,44 @@ TclClockFreeScan(
     /* parse */
     status = yyparse(info);
     if (status == 1) {
-	Tcl_SetObjResult(interp, info->messages);
-	Tcl_DecrRefCount(info->messages);
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "PARSE", NULL);
-	return TCL_ERROR;
+    	const char *msg = NULL;
+	if (info->errFlags & CLF_HAVEDATE) {
+	    msg = "more than one date in string";
+	} else if (info->errFlags & CLF_TIME) {
+	    msg = "more than one time of day in string";
+	} else if (info->errFlags & CLF_ZONE) {
+	    msg = "more than one time zone in string";
+	} else if (info->errFlags & CLF_DAYOFWEEK) {
+	    msg = "more than one weekday in string";
+	} else if (info->errFlags & CLF_ORDINALMONTH) {
+	    msg = "more than one ordinal month in string";
+	}
+	if (msg) {
+	    Tcl_SetObjResult(interp, Tcl_NewStringObj(msg, -1));
+	    Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
+	} else {
+	    Tcl_SetObjResult(interp,
+		info->messages ? info->messages : Tcl_NewObj());
+	    info->messages = NULL;
+	    Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "PARSE", NULL);
+	}
+	status = TCL_ERROR;
     } else if (status == 2) {
 	Tcl_SetObjResult(interp, Tcl_NewStringObj("memory exhausted", -1));
-	Tcl_DecrRefCount(info->messages);
 	Tcl_SetErrorCode(interp, "TCL", "MEMORY", NULL);
-	return TCL_ERROR;
+	status = TCL_ERROR;
     } else if (status != 0) {
 	Tcl_SetObjResult(interp, Tcl_NewStringObj("Unknown status returned "
 						  "from date parser. Please "
 						  "report this error as a "
 						  "bug in Tcl.", -1));
-	Tcl_DecrRefCount(info->messages);
 	Tcl_SetErrorCode(interp, "TCL", "BUG", NULL);
-	return TCL_ERROR;
+	status = TCL_ERROR;
     }
-    Tcl_DecrRefCount(info->messages);
-
-    if (info->errFlags & CLF_HAVEDATE) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one date in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
+    if (info->messages) {
+	Tcl_DecrRefCount(info->messages);
     }
-    if (info->errFlags & CLF_TIME) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one time of day in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-    if (info->errFlags & CLF_ZONE) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one time zone in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-    if (info->errFlags & CLF_DAYOFWEEK) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one weekday in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-    if (info->errFlags & CLF_ORDINALMONTH) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one ordinal month in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-
-    return TCL_OK;
+    return status;
 }
 
 /*

--- a/generic/tclDate.h
+++ b/generic/tclDate.h
@@ -76,6 +76,7 @@ MODULE_SCOPE size_t TclEnvEpoch;        /* Epoch of the tcl environment
 #define CLF_LOCALSEC	       (1 << 2)
 #define CLF_JULIANDAY	       (1 << 3)
 #define CLF_TIME	       (1 << 4)
+#define CLF_ZONE	       (1 << 5)
 #define CLF_CENTURY	       (1 << 6)
 #define CLF_DAYOFMONTH	       (1 << 7)
 #define CLF_DAYOFYEAR	       (1 << 8)
@@ -85,12 +86,19 @@ MODULE_SCOPE size_t TclEnvEpoch;        /* Epoch of the tcl environment
 #define CLF_ISO8601YEAR	       (1 << 12)
 #define CLF_ISO8601WEAK	       (1 << 13)
 #define CLF_ISO8601CENTURY     (1 << 14)
-#define CLF_SIGNED	       (1 << 15)
+
+#define CLF_SIGNED	       (1 << 16)
+
+/* extra flags used outside of scan/format-tokens too (int, not a short int) */
+#define CLF_RELCONV	       (1 << 17)
+#define CLF_ORDINALMONTH       (1 << 18)
+
 /* On demand (lazy) assemble flags */
 #define CLF_ASSEMBLE_DATE      (1 << 28) /* assemble year, month, etc. using julianDay */
 #define CLF_ASSEMBLE_JULIANDAY (1 << 29) /* assemble julianDay using year, month, etc. */
 #define CLF_ASSEMBLE_SECONDS   (1 << 30) /* assemble localSeconds (and seconds at end) */
 
+#define CLF_HAVEDATE	       (CLF_DAYOFMONTH|CLF_MONTH|CLF_YEAR|CLF_ISO8601YEAR)
 #define CLF_DATE	       (CLF_JULIANDAY | CLF_DAYOFMONTH | CLF_DAYOFYEAR | \
 				CLF_MONTH | CLF_YEAR | CLF_ISO8601YEAR | \
 				CLF_DAYOFWEEK | CLF_ISO8601WEAK)
@@ -224,28 +232,22 @@ typedef struct DateInfo {
 
     TclDateFields date;
 
-    int		flags;
-
-    int dateHaveDate;
+    int		flags;		/* Signals parts of date/time get found */
+    int		errFlags;	/* Signals error (part of date/time found twice) */
 
     int dateMeridian;
-    int dateHaveTime;
 
     int dateTimezone;
     int dateDSTmode;
-    int dateHaveZone;
 
     int dateRelMonth;
     int dateRelDay;
     int dateRelSeconds;
-    int dateHaveRel;
 
     int dateMonthOrdinalIncr;
     int dateMonthOrdinal;
-    int dateHaveOrdinalMonth;
 
     int dateDayOrdinal;
-    int dateHaveDay;
 
     int *dateRelPointer;
 
@@ -274,12 +276,6 @@ typedef struct DateInfo {
 #define yyDayOfWeek (info->date.dayOfWeek)
 #define yyMonthOrdinalIncr  (info->dateMonthOrdinalIncr)
 #define yyMonthOrdinal	(info->dateMonthOrdinal)
-#define yyHaveDate  (info->dateHaveDate)
-#define yyHaveDay   (info->dateHaveDay)
-#define yyHaveOrdinalMonth (info->dateHaveOrdinalMonth)
-#define yyHaveRel   (info->dateHaveRel)
-#define yyHaveTime  (info->dateHaveTime)
-#define yyHaveZone  (info->dateHaveZone)
 #define yyTimezone  (info->dateTimezone)
 #define yyMeridian  (info->dateMeridian)
 #define yyRelMonth  (info->dateRelMonth)

--- a/generic/tclDate.h
+++ b/generic/tclDate.h
@@ -87,7 +87,7 @@ MODULE_SCOPE size_t TclEnvEpoch;        /* Epoch of the tcl environment
 #define CLF_ISO8601WEAK	       (1 << 13)
 #define CLF_ISO8601CENTURY     (1 << 14)
 
-#define CLF_SIGNED	       (1 << 16)
+#define CLF_SIGNED	       (1 << 15)
 
 /* extra flags used outside of scan/format-tokens too (int, not a short int) */
 #define CLF_RELCONV	       (1 << 17)
@@ -98,7 +98,7 @@ MODULE_SCOPE size_t TclEnvEpoch;        /* Epoch of the tcl environment
 #define CLF_ASSEMBLE_JULIANDAY (1 << 29) /* assemble julianDay using year, month, etc. */
 #define CLF_ASSEMBLE_SECONDS   (1 << 30) /* assemble localSeconds (and seconds at end) */
 
-#define CLF_HAVEDATE	       (CLF_DAYOFMONTH|CLF_MONTH|CLF_YEAR|CLF_ISO8601YEAR)
+#define CLF_HAVEDATE	       (CLF_DAYOFMONTH|CLF_MONTH|CLF_YEAR)
 #define CLF_DATE	       (CLF_JULIANDAY | CLF_DAYOFMONTH | CLF_DAYOFYEAR | \
 				CLF_MONTH | CLF_YEAR | CLF_ISO8601YEAR | \
 				CLF_DAYOFWEEK | CLF_ISO8601WEAK)

--- a/generic/tclGetDate.y
+++ b/generic/tclGetDate.y
@@ -75,6 +75,13 @@
 #define SECSPERDAY	(24L * 60L * 60L)
 #define IsLeapYear(x)	((x % 4 == 0) && (x % 100 != 0 || x % 400 == 0))
 
+#define yyIncrFlags(f)				\
+    do {					\
+	info->errFlags |= (info->flags & (f));	\
+	if (info->errFlags) { YYABORT; }	\
+	info->flags |= (f);			\
+    } while (0);
+
 /*
  * An entry in the lexical lookup table.
  */
@@ -163,31 +170,28 @@ spec	: /* NULL */
 	;
 
 item	: time {
-	    yyHaveTime++;
+	    yyIncrFlags(CLF_TIME);
 	}
 	| zone {
-	    yyHaveZone++;
+	    yyIncrFlags(CLF_ZONE);
 	}
 	| date {
-	    yyHaveDate++;
+	    yyIncrFlags(CLF_HAVEDATE);
 	}
 	| ordMonth {
-	    yyHaveOrdinalMonth++;
+	    yyIncrFlags(CLF_ORDINALMONTH);
 	}
 	| day {
-	    yyHaveDay++;
+	    yyIncrFlags(CLF_DAYOFWEEK);
 	}
 	| relspec {
-	    yyHaveRel++;
+	    yyIncrFlags(CLF_RELCONV);
 	}
 	| iso {
-	    yyHaveTime++;
-	    yyHaveDate++;
+	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE);
 	}
 	| trek {
-	    yyHaveTime++;
-	    yyHaveDate++;
-	    yyHaveRel++;
+	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE|CLF_RELCONV);
 	}
 	| number
 	;
@@ -245,32 +249,26 @@ comma	: ','
 day	: tDAY {
 	    yyDayOrdinal = 1;
 	    yyDayOfWeek = $1;
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 	| tDAY comma {
 	    yyDayOrdinal = 1;
 	    yyDayOfWeek = $1;
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 	| tUNUMBER tDAY {
 	    yyDayOrdinal = $1;
 	    yyDayOfWeek = $2;
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 	| sign SP tUNUMBER tDAY {
 	    yyDayOrdinal = $1 * $3;
 	    yyDayOfWeek = $4;
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 	| sign tUNUMBER tDAY {
 	    yyDayOrdinal = $1 * $2;
 	    yyDayOfWeek = $3;
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 	| tNEXT tDAY {
 	    yyDayOrdinal = 2;
 	    yyDayOfWeek = $2;
-	    info->flags |= CLF_DAYOFWEEK;
 	}
 	;
 
@@ -450,10 +448,10 @@ INTNUM	: tUNUMBER {
 	;
 
 number	: INTNUM {
-	    if (yyHaveTime && yyHaveDate && !yyHaveRel) {
+	    if ((info->flags & (CLF_TIME|CLF_HAVEDATE|CLF_RELCONV)) == (CLF_TIME|CLF_HAVEDATE)) {
 		yyYear = $1;
 	    } else {
-		yyHaveTime++;
+		yyIncrFlags(CLF_TIME);
 		if (yyDigitCount <= 2) {
 		    yyHour = $1;
 		    yyMinutes = 0;
@@ -1031,31 +1029,31 @@ TclClockFreeScan(
     }
     Tcl_DecrRefCount(info->messages);
 
-    if (yyHaveDate > 1) {
+    if (info->errFlags & CLF_HAVEDATE) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one date in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveTime > 1) {
+    if (info->errFlags & CLF_TIME) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one time of day in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveZone > 1) {
+    if (info->errFlags & CLF_ZONE) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one time zone in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveDay > 1) {
+    if (info->errFlags & CLF_DAYOFWEEK) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one weekday in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
 	return TCL_ERROR;
     }
-    if (yyHaveOrdinalMonth > 1) {
+    if (info->errFlags & CLF_ORDINALMONTH) {
 	Tcl_SetObjResult(interp,
 		Tcl_NewStringObj("more than one ordinal month in string", -1));
 	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);

--- a/generic/tclGetDate.y
+++ b/generic/tclGetDate.y
@@ -185,13 +185,14 @@ item	: time {
 	    yyIncrFlags(CLF_DAYOFWEEK);
 	}
 	| relspec {
-	    yyIncrFlags(CLF_RELCONV);
+	    info->flags |= CLF_RELCONV;
 	}
 	| iso {
 	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE);
 	}
 	| trek {
-	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE|CLF_RELCONV);
+	    yyIncrFlags(CLF_TIME|CLF_HAVEDATE);
+	    info->flags |= CLF_RELCONV;
 	}
 	| number
 	;
@@ -700,6 +701,9 @@ TclDateerror(
     const char *s)
 {
     Tcl_Obj* t;
+    if (!infoPtr->messages) {
+	infoPtr->messages = Tcl_NewObj();
+    }
     Tcl_AppendToObj(infoPtr->messages, infoPtr->separatrix, -1);
     Tcl_AppendToObj(infoPtr->messages, s, -1);
     Tcl_AppendToObj(infoPtr->messages, " (characters ", -1);
@@ -997,9 +1001,7 @@ TclClockFreeScan(
 
     yyDSTmode = DSTmaybe;
 
-    info->messages = Tcl_NewObj();
     info->separatrix = "";
-    Tcl_IncrRefCount(info->messages);
 
     info->dateStart = yyInput;
 
@@ -1009,58 +1011,44 @@ TclClockFreeScan(
     /* parse */
     status = yyparse(info);
     if (status == 1) {
-	Tcl_SetObjResult(interp, info->messages);
-	Tcl_DecrRefCount(info->messages);
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "PARSE", NULL);
-	return TCL_ERROR;
+    	const char *msg = NULL;
+	if (info->errFlags & CLF_HAVEDATE) {
+	    msg = "more than one date in string";
+	} else if (info->errFlags & CLF_TIME) {
+	    msg = "more than one time of day in string";
+	} else if (info->errFlags & CLF_ZONE) {
+	    msg = "more than one time zone in string";
+	} else if (info->errFlags & CLF_DAYOFWEEK) {
+	    msg = "more than one weekday in string";
+	} else if (info->errFlags & CLF_ORDINALMONTH) {
+	    msg = "more than one ordinal month in string";
+	}
+	if (msg) {
+	    Tcl_SetObjResult(interp, Tcl_NewStringObj(msg, -1));
+	    Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
+	} else {
+	    Tcl_SetObjResult(interp,
+		info->messages ? info->messages : Tcl_NewObj());
+	    info->messages = NULL;
+	    Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "PARSE", NULL);
+	}
+	status = TCL_ERROR;
     } else if (status == 2) {
 	Tcl_SetObjResult(interp, Tcl_NewStringObj("memory exhausted", -1));
-	Tcl_DecrRefCount(info->messages);
 	Tcl_SetErrorCode(interp, "TCL", "MEMORY", NULL);
-	return TCL_ERROR;
+	status = TCL_ERROR;
     } else if (status != 0) {
 	Tcl_SetObjResult(interp, Tcl_NewStringObj("Unknown status returned "
 						  "from date parser. Please "
 						  "report this error as a "
 						  "bug in Tcl.", -1));
-	Tcl_DecrRefCount(info->messages);
 	Tcl_SetErrorCode(interp, "TCL", "BUG", NULL);
-	return TCL_ERROR;
+	status = TCL_ERROR;
     }
-    Tcl_DecrRefCount(info->messages);
-
-    if (info->errFlags & CLF_HAVEDATE) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one date in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
+    if (info->messages) {
+	Tcl_DecrRefCount(info->messages);
     }
-    if (info->errFlags & CLF_TIME) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one time of day in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-    if (info->errFlags & CLF_ZONE) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one time zone in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-    if (info->errFlags & CLF_DAYOFWEEK) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one weekday in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-    if (info->errFlags & CLF_ORDINALMONTH) {
-	Tcl_SetObjResult(interp,
-		Tcl_NewStringObj("more than one ordinal month in string", -1));
-	Tcl_SetErrorCode(interp, "TCL", "VALUE", "DATE", "MULTIPLE", NULL);
-	return TCL_ERROR;
-    }
-
-    return TCL_OK;
+    return status;
 }
 
 /*


### PR DESCRIPTION
* simplifying info-structure, usage of flags etc (normalizing in order to use same flags as by formatted scan instead of members like `yyHave...`);
* optimized validation rules depending on flags;
* small performance improvement: allocates `info->messages` object on demand, only if free (yacc) scan fails;
